### PR TITLE
Add support Edit ContainerMount for kata/direct volume

### DIFF
--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -232,7 +232,10 @@ func (c *Cache) InjectDevices(ociSpec *oci.Spec, devices ...string) ([]string, e
 	for _, device := range devices {
 		d := c.devices[device]
 		if d == nil {
-			unresolved = append(unresolved, device)
+			// In kata direct-volume case, no need to unresolve it.
+			if !strings.HasPrefix(device, "kata.direct.volume") {
+				unresolved = append(unresolved, device)
+			}
 			continue
 		}
 		if _, ok := specs[d.GetSpec()]; !ok {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -184,15 +184,13 @@ func ValidateDeviceName(name string) error {
 	for _, c := range string(name[1 : len(name)-1]) {
 		switch {
 		case IsAlphaNumeric(c):
-		case c == '_' || c == '-' || c == '.' || c == ':':
+		case c == '_' || c == '-' || c == '.' || c == ':' || c == '=':
 		default:
 			return fmt.Errorf("invalid character '%c' in device name %q",
 				c, name)
 		}
 	}
-	if !IsAlphaNumeric(rune(name[len(name)-1])) {
-		return fmt.Errorf("invalid name %q, should end with a letter or digit", name)
-	}
+
 	return nil
 }
 


### PR DESCRIPTION
Add support Edit Container Mount for kata/runtime-rs using direct volume in K8S/CSI scenario.

Fixes: #162