### PR TITLE
make specs-go a module

### DIFF
--- a/cmd/cdi/go.mod
+++ b/cmd/cdi/go.mod
@@ -12,6 +12,7 @@ require (
 )
 
 require (
+	github.com/container-orchestrated-devices/container-device-interface/specs-go v0.0.0-00010101000000-000000000000 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/opencontainers/selinux v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
@@ -25,3 +26,5 @@ require (
 )
 
 replace github.com/container-orchestrated-devices/container-device-interface => ../..
+
+replace github.com/container-orchestrated-devices/container-device-interface/specs-go => ../../specs-go

--- a/cmd/validate/go.mod
+++ b/cmd/validate/go.mod
@@ -13,3 +13,5 @@ require (
 )
 
 replace github.com/container-orchestrated-devices/container-device-interface => ../..
+
+replace github.com/container-orchestrated-devices/container-device-interface/specs-go => ../../specs-go

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/container-orchestrated-devices/container-device-interface
 go 1.19
 
 require (
+	github.com/container-orchestrated-devices/container-device-interface/specs-go v0.0.0-00010101000000-000000000000
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/opencontainers/runtime-spec v1.1.0
 	github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626
@@ -22,3 +23,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/container-orchestrated-devices/container-device-interface/specs-go => ./specs-go

--- a/go.sum
+++ b/go.sum
@@ -13,7 +13,6 @@ github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9
 github.com/mndrix/tap-go v0.0.0-20171203230836-629fa407e90b/go.mod h1:pzzDgJWZ34fGzaAZGFW22KVZDfyrYW+QABMrWnJBnSs=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
-github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bll4AjJ9odEGpg=
 github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626 h1:DmNGcqH3WDbV5k8OJ+esPWbqUOX5rMLR2PMvziDMJi0=

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9
 github.com/mndrix/tap-go v0.0.0-20171203230836-629fa407e90b/go.mod h1:pzzDgJWZ34fGzaAZGFW22KVZDfyrYW+QABMrWnJBnSs=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bll4AjJ9odEGpg=
 github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626 h1:DmNGcqH3WDbV5k8OJ+esPWbqUOX5rMLR2PMvziDMJi0=

--- a/specs-go/go.mod
+++ b/specs-go/go.mod
@@ -1,0 +1,5 @@
+module github.com/container-orchestrated-devices/container-device-interface/specs-go
+
+go 1.19
+
+require github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78

--- a/specs-go/go.sum
+++ b/specs-go/go.sum
@@ -1,0 +1,2 @@
+github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78 h1:R5M2qXZiK/mWPMT4VldCOiSL9HIAMuxQZWdG0CSM5+4=
+github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=


### PR DESCRIPTION
This should allow to import CDI spec structures without adding a lot of CDI runtime deps.

It should partly fix #97  and allow Kubernetes to refer this module directly. There are at least 2 places in the k/k codebase that would benefit from this change:
- this can be replaced by the specs-go import: https://github.com/kubernetes/kubernetes/blob/master/test/e2e/dra/test-driver/app/cdi.go
- this can import specs-go and use JSON marshalling instead of quite ugly approach it uses to write CDI files: https://github.com/kubernetes/kubernetes/blob/master/test/images/sample-device-plugin/sampledeviceplugin.go#L237