### PR TITLE
Use tags.cncf.io URL in module names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CDI - The Container Device Interface
 
-**NOTE:** The API for injecting CDI devices that existed at `github.com/container-orchestrated-devices/container-device-interface/pkg` has been removed. Users of this API should migrate to the one at `https://github.com/cncf-tags/container-device-interface/tree/main/pkg/cdi` as this is actively maintained.
+**NOTE:** The API for injecting CDI devices that existed at `container-device-interface/pkg` has been removed. Users of this API should migrate to the one at `container-device-interface/pkg/cdi` as this is actively maintained.
 
 ## What is CDI?
 
@@ -188,5 +188,5 @@ EOF
 
 [Check out the Contributing document!](CONTRIBUTING.md)
 
-* Please let us know by [filing a new issue](https://github.com/container-orchestrated-devices/container-device-interface/issues/new)
+* Please let us know by [filing a new issue](https://github.com/cncf-tags/container-device-interface/issues/new)
 * You can contribute by opening a [pull request](https://help.github.com/articles/using-pull-requests/)

--- a/cmd/cdi/cmd/cdi-api.go
+++ b/cmd/cdi/cmd/cdi-api.go
@@ -22,9 +22,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	gen "github.com/opencontainers/runtime-tools/generate"
+	"tags.cncf.io/container-device-interface/pkg/cdi"
 )
 
 func cdiListVendors() {

--- a/cmd/cdi/cmd/monitor.go
+++ b/cmd/cdi/cmd/monitor.go
@@ -25,7 +25,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
 
-	cdi "github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
+	cdi "tags.cncf.io/container-device-interface/pkg/cdi"
 )
 
 type monitorFlags struct {

--- a/cmd/cdi/cmd/root.go
+++ b/cmd/cdi/cmd/root.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
-	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi/validate"
-	"github.com/container-orchestrated-devices/container-device-interface/schema"
+	"tags.cncf.io/container-device-interface/pkg/cdi"
+	"tags.cncf.io/container-device-interface/pkg/cdi/validate"
+	"tags.cncf.io/container-device-interface/schema"
 )
 
 var (

--- a/cmd/cdi/cmd/specs.go
+++ b/cmd/cdi/cmd/specs.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
 	"github.com/spf13/cobra"
+	"tags.cncf.io/container-device-interface/pkg/cdi"
 )
 
 type specFlags struct {

--- a/cmd/cdi/cmd/validate.go
+++ b/cmd/cdi/cmd/validate.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
+	"tags.cncf.io/container-device-interface/pkg/cdi"
 )
 
 // validateCmd is our CDI command for validating CDI Spec files in the registry.

--- a/cmd/cdi/go.mod
+++ b/cmd/cdi/go.mod
@@ -1,18 +1,17 @@
-module github.com/container-orchestrated-devices/container-device-interface/cmd/cdi
+module tags.cncf.io/container-device-interface/cmd/cdi
 
 go 1.19
 
 require (
-	github.com/container-orchestrated-devices/container-device-interface v0.0.0
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/opencontainers/runtime-spec v1.1.0
 	github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626
 	github.com/spf13/cobra v1.6.0
 	sigs.k8s.io/yaml v1.3.0
+	tags.cncf.io/container-device-interface v0.0.0
 )
 
 require (
-	github.com/container-orchestrated-devices/container-device-interface/specs-go v0.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/opencontainers/selinux v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
@@ -23,8 +22,9 @@ require (
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	tags.cncf.io/container-device-interface/specs-go v0.6.0 // indirect
 )
 
-replace github.com/container-orchestrated-devices/container-device-interface => ../..
+replace tags.cncf.io/container-device-interface => ../..
 
-replace github.com/container-orchestrated-devices/container-device-interface/specs-go => ../../specs-go
+replace tags.cncf.io/container-device-interface/specs-go => ../../specs-go

--- a/cmd/cdi/main.go
+++ b/cmd/cdi/main.go
@@ -16,7 +16,7 @@
 
 package main
 
-import "github.com/container-orchestrated-devices/container-device-interface/cmd/cdi/cmd"
+import "tags.cncf.io/container-device-interface/cmd/cdi/cmd"
 
 func main() {
 	cmd.Execute()

--- a/cmd/validate/go.mod
+++ b/cmd/validate/go.mod
@@ -1,8 +1,8 @@
-module github.com/container-orchestrated-devices/container-device-interface/cmd/validate
+module tags.cncf.io/container-device-interface/cmd/validate
 
 go 1.19
 
-require github.com/container-orchestrated-devices/container-device-interface v0.0.0
+require tags.cncf.io/container-device-interface v0.0.0
 
 require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
@@ -12,6 +12,6 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/container-orchestrated-devices/container-device-interface => ../..
+replace tags.cncf.io/container-device-interface => ../..
 
-replace github.com/container-orchestrated-devices/container-device-interface/specs-go => ../../specs-go
+replace tags.cncf.io/container-device-interface/specs-go => ../../specs-go

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -25,7 +25,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/container-orchestrated-devices/container-device-interface/schema"
+	"tags.cncf.io/container-device-interface/schema"
 )
 
 const usage = `Validate is used to check document with specified schema.

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
-module github.com/container-orchestrated-devices/container-device-interface
+module tags.cncf.io/container-device-interface
 
 go 1.19
 
 require (
-	github.com/container-orchestrated-devices/container-device-interface/specs-go v0.6.0
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/opencontainers/runtime-spec v1.1.0
 	github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626
@@ -12,6 +11,7 @@ require (
 	golang.org/x/mod v0.4.2
 	golang.org/x/sys v0.1.0
 	sigs.k8s.io/yaml v1.3.0
+	tags.cncf.io/container-device-interface/specs-go v0.6.0
 )
 
 require (
@@ -24,4 +24,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/container-orchestrated-devices/container-device-interface/specs-go => ./specs-go
+replace tags.cncf.io/container-device-interface/specs-go => ./specs-go

--- a/internal/validation/k8s/objectmeta.go
+++ b/internal/validation/k8s/objectmeta.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/container-orchestrated-devices/container-device-interface/internal/multierror"
+	"tags.cncf.io/container-device-interface/internal/multierror"
 )
 
 // TotalAnnotationSizeLimitB defines the maximum size of all annotations in characters.

--- a/internal/validation/validate.go
+++ b/internal/validation/validate.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/container-orchestrated-devices/container-device-interface/internal/validation/k8s"
+	"tags.cncf.io/container-device-interface/internal/validation/k8s"
 )
 
 // ValidateSpecAnnotations checks whether spec annotations are valid.

--- a/pkg/cdi/annotations.go
+++ b/pkg/cdi/annotations.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/container-orchestrated-devices/container-device-interface/pkg/parser"
+	"tags.cncf.io/container-device-interface/pkg/parser"
 )
 
 const (

--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -26,10 +26,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/container-orchestrated-devices/container-device-interface/internal/multierror"
-	cdi "github.com/container-orchestrated-devices/container-device-interface/specs-go"
 	"github.com/fsnotify/fsnotify"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
+	"tags.cncf.io/container-device-interface/internal/multierror"
+	cdi "tags.cncf.io/container-device-interface/specs-go"
 )
 
 // Option is an option to change some aspect of default CDI behavior.

--- a/pkg/cdi/cache_test.go
+++ b/pkg/cdi/cache_test.go
@@ -27,11 +27,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi/validate"
-	cdi "github.com/container-orchestrated-devices/container-device-interface/specs-go"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
+	"tags.cncf.io/container-device-interface/pkg/cdi/validate"
+	cdi "tags.cncf.io/container-device-interface/specs-go"
 )
 
 func TestNewCache(t *testing.T) {

--- a/pkg/cdi/container-edits.go
+++ b/pkg/cdi/container-edits.go
@@ -24,9 +24,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/container-orchestrated-devices/container-device-interface/specs-go"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	ocigen "github.com/opencontainers/runtime-tools/generate"
+	"tags.cncf.io/container-device-interface/specs-go"
 )
 
 const (

--- a/pkg/cdi/container-edits_test.go
+++ b/pkg/cdi/container-edits_test.go
@@ -19,9 +19,9 @@ package cdi
 import (
 	"testing"
 
-	cdi "github.com/container-orchestrated-devices/container-device-interface/specs-go"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/require"
+	cdi "tags.cncf.io/container-device-interface/specs-go"
 )
 
 func TestValidateContainerEdits(t *testing.T) {

--- a/pkg/cdi/device.go
+++ b/pkg/cdi/device.go
@@ -19,10 +19,10 @@ package cdi
 import (
 	"fmt"
 
-	"github.com/container-orchestrated-devices/container-device-interface/internal/validation"
-	"github.com/container-orchestrated-devices/container-device-interface/pkg/parser"
-	cdi "github.com/container-orchestrated-devices/container-device-interface/specs-go"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
+	"tags.cncf.io/container-device-interface/internal/validation"
+	"tags.cncf.io/container-device-interface/pkg/parser"
+	cdi "tags.cncf.io/container-device-interface/specs-go"
 )
 
 // Device represents a CDI device of a Spec.

--- a/pkg/cdi/device_test.go
+++ b/pkg/cdi/device_test.go
@@ -19,8 +19,8 @@ package cdi
 import (
 	"testing"
 
-	cdi "github.com/container-orchestrated-devices/container-device-interface/specs-go"
 	"github.com/stretchr/testify/require"
+	cdi "tags.cncf.io/container-device-interface/specs-go"
 )
 
 func TestDeviceValidate(t *testing.T) {

--- a/pkg/cdi/doc.go
+++ b/pkg/cdi/doc.go
@@ -2,7 +2,7 @@
 // interacting with CDI and consuming CDI devices.
 //
 // For more information about Container Device Interface, please refer to
-// https://github.com/container-orchestrated-devices/container-device-interface
+// https://tags.cncf.io/container-device-interface
 //
 // # Container Device Interface
 //
@@ -48,7 +48,7 @@
 //
 //	    log "github.com/sirupsen/logrus"
 //
-//	    "github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
+//	    "tags.cncf.io/container-device-interface/pkg/cdi"
 //	    oci "github.com/opencontainers/runtime-spec/specs-go"
 //	)
 //
@@ -91,7 +91,7 @@
 //
 //	    log "github.com/sirupsen/logrus"
 //
-//	    "github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
+//	    "tags.cncf.io/container-device-interface/pkg/cdi"
 //	    oci "github.com/opencontainers/runtime-spec/specs-go"
 //	)
 //
@@ -172,8 +172,8 @@
 //
 //	"fmt"
 //	...
-//	"github.com/container-orchestrated-devices/container-device-interface/specs-go"
-//	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
+//	"tags.cncf.io/container-device-interface/specs-go"
+//	"tags.cncf.io/container-device-interface/pkg/cdi"
 //
 // )
 //
@@ -209,8 +209,8 @@
 //
 //	"fmt"
 //	...
-//	"github.com/container-orchestrated-devices/container-device-interface/specs-go"
-//	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
+//	"tags.cncf.io/container-device-interface/specs-go"
+//	"tags.cncf.io/container-device-interface/pkg/cdi"
 //
 // )
 //

--- a/pkg/cdi/qualified-device.go
+++ b/pkg/cdi/qualified-device.go
@@ -17,7 +17,7 @@
 package cdi
 
 import (
-	"github.com/container-orchestrated-devices/container-device-interface/pkg/parser"
+	"tags.cncf.io/container-device-interface/pkg/parser"
 )
 
 // QualifiedName returns the qualified name for a device.

--- a/pkg/cdi/registry.go
+++ b/pkg/cdi/registry.go
@@ -19,8 +19,8 @@ package cdi
 import (
 	"sync"
 
-	cdi "github.com/container-orchestrated-devices/container-device-interface/specs-go"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
+	cdi "tags.cncf.io/container-device-interface/specs-go"
 )
 
 // Registry keeps a cache of all CDI Specs installed or generated on

--- a/pkg/cdi/spec.go
+++ b/pkg/cdi/spec.go
@@ -28,8 +28,8 @@ import (
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	"sigs.k8s.io/yaml"
 
-	"github.com/container-orchestrated-devices/container-device-interface/internal/validation"
-	cdi "github.com/container-orchestrated-devices/container-device-interface/specs-go"
+	"tags.cncf.io/container-device-interface/internal/validation"
+	cdi "tags.cncf.io/container-device-interface/specs-go"
 )
 
 const (

--- a/pkg/cdi/spec_test.go
+++ b/pkg/cdi/spec_test.go
@@ -26,11 +26,11 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi/validate"
-	"github.com/container-orchestrated-devices/container-device-interface/pkg/parser"
-	"github.com/container-orchestrated-devices/container-device-interface/schema"
-	cdi "github.com/container-orchestrated-devices/container-device-interface/specs-go"
 	"github.com/stretchr/testify/require"
+	"tags.cncf.io/container-device-interface/pkg/cdi/validate"
+	"tags.cncf.io/container-device-interface/pkg/parser"
+	"tags.cncf.io/container-device-interface/schema"
+	cdi "tags.cncf.io/container-device-interface/specs-go"
 )
 
 func TestReadSpec(t *testing.T) {

--- a/pkg/cdi/validate/schema.go
+++ b/pkg/cdi/validate/schema.go
@@ -17,8 +17,8 @@
 package validate
 
 import (
-	"github.com/container-orchestrated-devices/container-device-interface/schema"
-	raw "github.com/container-orchestrated-devices/container-device-interface/specs-go"
+	"tags.cncf.io/container-device-interface/schema"
+	raw "tags.cncf.io/container-device-interface/specs-go"
 )
 
 const (

--- a/pkg/cdi/version.go
+++ b/pkg/cdi/version.go
@@ -21,8 +21,8 @@ import (
 
 	"golang.org/x/mod/semver"
 
-	"github.com/container-orchestrated-devices/container-device-interface/pkg/parser"
-	cdi "github.com/container-orchestrated-devices/container-device-interface/specs-go"
+	"tags.cncf.io/container-device-interface/pkg/parser"
+	cdi "tags.cncf.io/container-device-interface/specs-go"
 )
 
 const (

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -29,9 +29,9 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"github.com/container-orchestrated-devices/container-device-interface/internal/multierror"
-	"github.com/container-orchestrated-devices/container-device-interface/internal/validation"
 	schema "github.com/xeipuuv/gojsonschema"
+	"tags.cncf.io/container-device-interface/internal/multierror"
+	"tags.cncf.io/container-device-interface/internal/validation"
 )
 
 const (

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/container-orchestrated-devices/container-device-interface/pkg/cdi"
-	"github.com/container-orchestrated-devices/container-device-interface/schema"
+	"tags.cncf.io/container-device-interface/pkg/cdi"
+	"tags.cncf.io/container-device-interface/schema"
 )
 
 var (

--- a/specs-go/go.mod
+++ b/specs-go/go.mod
@@ -1,4 +1,4 @@
-module github.com/container-orchestrated-devices/container-device-interface/specs-go
+module tags.cncf.io/container-device-interface/specs-go
 
 go 1.19
 


### PR DESCRIPTION
With https://github.com/cncf/toc/issues/1152 addressed, we are able to use the `tags.cncf.io` vanity URL in our module names.