### PR TITLE
Add version to spec-go dependency

### DIFF
--- a/cmd/cdi/go.mod
+++ b/cmd/cdi/go.mod
@@ -12,7 +12,7 @@ require (
 )
 
 require (
-	github.com/container-orchestrated-devices/container-device-interface/specs-go v0.0.0-00010101000000-000000000000 // indirect
+	github.com/container-orchestrated-devices/container-device-interface/specs-go v0.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/opencontainers/selinux v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/container-orchestrated-devices/container-device-interface
 go 1.19
 
 require (
-	github.com/container-orchestrated-devices/container-device-interface/specs-go v0.0.0-00010101000000-000000000000
+	github.com/container-orchestrated-devices/container-device-interface/specs-go v0.6.0
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/opencontainers/runtime-spec v1.1.0
 	github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626


### PR DESCRIPTION
This change adds a v0.6.0 version to the internal specs-go dependency. This prevents a transitive dependency on the v0.0.0-00010101000000-000000000000 pseudo version when importing the package into clients.