### PR TITLE
Use v0.6.0-1 for internal specs-go dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	golang.org/x/mod v0.4.2
 	golang.org/x/sys v0.1.0
 	sigs.k8s.io/yaml v1.3.0
-	tags.cncf.io/container-device-interface/specs-go v0.6.0
+	tags.cncf.io/container-device-interface/specs-go v0.6.0-1
 )
 
 require (


### PR DESCRIPTION
Since we already have a `v0.6.0` tag, this seems to conflict (when checking the module checksums) with the `specs-go/v0.6.0` tag. 

This change will imply the use of the `specs-go/v0.6.0-1` tag for this release of this module.