### PR TITLE
Add AdditionalGIDs field to ContainerEdits

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -29,6 +29,7 @@ Released versions of the spec are available as Git tags.
 | v0.6.0 |   | Add `Annotations` field to `Spec` and `Device` specifications |
 |        |   | Allow dots (`.`)  in name segment of `Kind` field. |
 | v0.7.0 |   | Add `IntelRdt`field. |
+| v0.7.0 |   | Add `AdditionalGIDs` to `ContainerEdits` |
 
 *Note*: The initial release of a **spec** with version `v0.x.0` will be tagged as
 `v0.x.0` with subsequent changes to the API applicable to this version tagged as `v0.x.y`.
@@ -150,6 +151,11 @@ The keywords "must", "must not", "required", "shall", "shall not", "should", "sh
                     "env":  [ "<envName>=<envValue>"], (optional)
                     "timeout": <int> (optional)
                 }
+            ],
+            // Additional GIDs to add to the container process.
+            // Note that a value of 0 is ignored.
+            additionalGIDs: [ (optional)
+              <uint32>
             ]
             "intelRdt": { (optional)
                 "closID": "<name>", (optional)
@@ -234,6 +240,7 @@ The `containerEdits` field has the following definition:
     * `memBwSchema` (string, OPTIONAL) memory bandwidth allocation schema for the `CLOS`.
     * `enableCMT` (boolean, OPTIONAL) whether to enable cache monitoring
     * `enableMBM` (boolean, OPTIONAL) whether to enable memory bandwidth monitoring
+  * `additionalGids` (array of uint32s, OPTIONAL) A list of additional group IDs to add with the container process. These values are added to the `user.additionalGids` field in the OCI runtime specification. Values of 0 are ignored.
 
 ## Error Handling
   * Kind requested is not present in any CDI file.

--- a/pkg/cdi/container-edits.go
+++ b/pkg/cdi/container-edits.go
@@ -225,7 +225,25 @@ func (e *ContainerEdits) isEmpty() bool {
 	if e == nil {
 		return false
 	}
-	return len(e.Env)+len(e.DeviceNodes)+len(e.Hooks)+len(e.Mounts)+len(e.AdditionalGIDs) == 0 && e.IntelRdt == nil
+	if len(e.Env) > 0 {
+		return false
+	}
+	if len(e.DeviceNodes) > 0 {
+		return false
+	}
+	if len(e.Hooks) > 0 {
+		return false
+	}
+	if len(e.Mounts) > 0 {
+		return false
+	}
+	if len(e.AdditionalGIDs) > 0 {
+		return false
+	}
+	if e.IntelRdt != nil {
+		return false
+	}
+	return true
 }
 
 // ValidateEnv validates the given environment variables.

--- a/pkg/cdi/container-edits.go
+++ b/pkg/cdi/container-edits.go
@@ -151,6 +151,13 @@ func (e *ContainerEdits) Apply(spec *oci.Spec) error {
 		spec.Linux.IntelRdt = e.IntelRdt.ToOCI()
 	}
 
+	for _, additionalGID := range e.AdditionalGIDs {
+		if additionalGID == 0 {
+			continue
+		}
+		specgen.AddProcessAdditionalGid(additionalGID)
+	}
+
 	return nil
 }
 
@@ -207,6 +214,7 @@ func (e *ContainerEdits) Append(o *ContainerEdits) *ContainerEdits {
 	if o.IntelRdt != nil {
 		e.IntelRdt = o.IntelRdt
 	}
+	e.AdditionalGIDs = append(e.AdditionalGIDs, o.AdditionalGIDs...)
 
 	return e
 }
@@ -217,7 +225,7 @@ func (e *ContainerEdits) isEmpty() bool {
 	if e == nil {
 		return false
 	}
-	return len(e.Env)+len(e.DeviceNodes)+len(e.Hooks)+len(e.Mounts) == 0 && e.IntelRdt == nil
+	return len(e.Env)+len(e.DeviceNodes)+len(e.Hooks)+len(e.Mounts)+len(e.AdditionalGIDs) == 0 && e.IntelRdt == nil
 }
 
 // ValidateEnv validates the given environment variables.

--- a/pkg/cdi/spec_test.go
+++ b/pkg/cdi/spec_test.go
@@ -695,6 +695,30 @@ func TestRequiredVersion(t *testing.T) {
 			},
 			expectedVersion: "0.7.0",
 		},
+		{
+			description: "additionalGIDs in spec require v0.7.0",
+			spec: &cdi.Spec{
+				ContainerEdits: cdi.ContainerEdits{
+					AdditionalGIDs: []uint32{5},
+				},
+			},
+			expectedVersion: "0.7.0",
+		},
+		{
+
+			description: "additionalGIDs in device require v0.7.0",
+			spec: &cdi.Spec{
+				Devices: []cdi.Device{
+					{
+						Name: "device0",
+						ContainerEdits: cdi.ContainerEdits{
+							AdditionalGIDs: []uint32{5},
+						},
+					},
+				},
+			},
+			expectedVersion: "0.7.0",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/cdi/version.go
+++ b/pkg/cdi/version.go
@@ -125,9 +125,17 @@ func requiresV070(spec *cdi.Spec) bool {
 	if spec.ContainerEdits.IntelRdt != nil {
 		return true
 	}
+	// The v0.7.0 spec allows additional GIDs to be specified at a spec level.
+	if len(spec.ContainerEdits.AdditionalGIDs) > 0 {
+		return true
+	}
 
 	for _, d := range spec.Devices {
 		if d.ContainerEdits.IntelRdt != nil {
+			return true
+		}
+		// The v0.7.0 spec allows additional GIDs to be specified at a device level.
+		if len(d.ContainerEdits.AdditionalGIDs) > 0 {
 			return true
 		}
 	}

--- a/schema/defs.json
+++ b/schema/defs.json
@@ -157,6 +157,12 @@
                             "type": "boolean"
                         }
                     }
+                },
+                "additionalGids": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/uint32"
+                    }
                 }
             }
         },

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -3,7 +3,7 @@ package specs
 import "os"
 
 // CurrentVersion is the current version of the Spec.
-const CurrentVersion = "0.6.0"
+const CurrentVersion = "0.7.0"
 
 // Spec is the base configuration for CDI
 type Spec struct {
@@ -25,11 +25,12 @@ type Device struct {
 
 // ContainerEdits are edits a container runtime must make to the OCI spec to expose the device.
 type ContainerEdits struct {
-	Env         []string      `json:"env,omitempty"`
-	DeviceNodes []*DeviceNode `json:"deviceNodes,omitempty"`
-	Hooks       []*Hook       `json:"hooks,omitempty"`
-	Mounts      []*Mount      `json:"mounts,omitempty"`
-	IntelRdt    *IntelRdt     `json:"intelRdt,omitempty"`
+	Env            []string      `json:"env,omitempty"`
+	DeviceNodes    []*DeviceNode `json:"deviceNodes,omitempty"`
+	Hooks          []*Hook       `json:"hooks,omitempty"`
+	Mounts         []*Mount      `json:"mounts,omitempty"`
+	IntelRdt       *IntelRdt     `json:"intelRdt,omitempty"`
+	AdditionalGIDs []uint32      `json:"additionalGids,omitempty"`
 }
 
 // DeviceNode represents a device node that needs to be added to the OCI spec.


### PR DESCRIPTION
This change adds an AdditionalGIDs field to the ContainerEdits structure. This allows CDI spec producers to associate a group ID with the container's user to allow access to, for example, device nodes with specific permissions.

This closes #175 