### PR TITLE
chore: stop using deprecated io/ioutil package

### DIFF
--- a/cmd/cdi/cmd/inject.go
+++ b/cmd/cdi/cmd/inject.go
@@ -18,7 +18,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	oci "github.com/opencontainers/runtime-spec/specs-go"
@@ -66,9 +66,9 @@ func readOCISpec(path string) (*oci.Spec, error) {
 	)
 
 	if path == "-" {
-		data, err = ioutil.ReadAll(os.Stdin)
+		data, err = io.ReadAll(os.Stdin)
 	} else {
-		data, err = ioutil.ReadFile(path)
+		data, err = os.ReadFile(path)
 	}
 
 	if err != nil {

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -22,7 +22,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"tags.cncf.io/container-device-interface/schema"
@@ -80,7 +80,7 @@ func main() {
 	for _, docFile = range docs {
 		if docFile == "" || docFile == "-" {
 			docFile = "<stdin>"
-			docData, err = ioutil.ReadAll(os.Stdin)
+			docData, err = io.ReadAll(os.Stdin)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "failed to read document data from stdin: %v\n", err)
 				os.Exit(1)

--- a/pkg/cdi/spec-dirs_test.go
+++ b/pkg/cdi/spec-dirs_test.go
@@ -18,7 +18,6 @@ package cdi
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -212,7 +211,7 @@ devices:
 
 // Create an automatically cleaned up temporary directory, with optional content.
 func mkTestDir(t *testing.T, dirs map[string]map[string]string) (string, error) {
-	tmp, err := ioutil.TempDir("", ".cache-test*")
+	tmp, err := os.MkdirTemp("", ".cache-test*")
 	if err != nil {
 		return "", fmt.Errorf("failed to create test directory: %w", err)
 	}
@@ -237,7 +236,7 @@ func updateTestDir(t *testing.T, tmp string, dirs map[string]map[string]string) 
 		for file, data := range content {
 			file := filepath.Join(dir, file)
 			tmp := file + ".tmp"
-			if err := ioutil.WriteFile(tmp, []byte(data), 0644); err != nil {
+			if err := os.WriteFile(tmp, []byte(data), 0644); err != nil {
 				return fmt.Errorf("failed to write file %q: %w", tmp, err)
 			}
 			if err := os.Rename(tmp, file); err != nil {

--- a/pkg/cdi/spec.go
+++ b/pkg/cdi/spec.go
@@ -19,7 +19,6 @@ package cdi
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -62,7 +61,7 @@ type Spec struct {
 // assigned the given priority. If reading or parsing the Spec
 // data fails ReadSpec returns a nil Spec and an error.
 func ReadSpec(path string, priority int) (*Spec, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	switch {
 	case os.IsNotExist(err):
 		return nil, err

--- a/pkg/cdi/spec_test.go
+++ b/pkg/cdi/spec_test.go
@@ -18,7 +18,6 @@ package cdi
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -496,7 +495,7 @@ devices:
 
 // Create an automatically cleaned up temporary file for a test.
 func mkTestSpec(t *testing.T, data []byte) (string, error) {
-	tmp, err := ioutil.TempFile("", ".cdi-test.*."+specType(data))
+	tmp, err := os.CreateTemp("", ".cdi-test.*."+specType(data))
 	if err != nil {
 		return "", fmt.Errorf("failed to create test file: %w", err)
 	}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -22,8 +22,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -158,7 +158,7 @@ func Load(source string) (*Schema, error) {
 // ReadAndValidate all data from the given reader, using the schema for validation.
 func (s *Schema) ReadAndValidate(r io.Reader) ([]byte, error) {
 	loader, reader := schema.NewReaderLoader(r)
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read data for validation: %w", err)
 	}
@@ -202,7 +202,7 @@ func (s *Schema) ValidateFile(path string) error {
 		return s.validate(schema.NewReferenceLoader("file://" + path))
 	}
 
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -269,7 +268,7 @@ func validateFile(t *testing.T, scm *schema.Schema, path string, shouldLoad, isV
 }
 
 func validateData(t *testing.T, scm *schema.Schema, path string, shouldLoad, isValid bool) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	require.NoError(t, err)
 
 	if scm != nil {


### PR DESCRIPTION
Replace with corresponding functions from io and os packages.