### PR TITLE
chore: code cleanup

### DIFF
--- a/pkg/cdi/cache_test.go
+++ b/pkg/cdi/cache_test.go
@@ -718,7 +718,7 @@ devices:
 					}
 
 					select {
-					case _ = <-stopCh:
+					case <-stopCh:
 						return
 					default:
 					}
@@ -748,7 +748,7 @@ devices:
 					}
 
 					select {
-					case _ = <-stopCh:
+					case <-stopCh:
 						return
 					default:
 					}
@@ -771,10 +771,10 @@ devices:
 				// from updater()'s create+write+rename loop)
 				for {
 					select {
-					case _ = <-stopCh:
+					case <-stopCh:
 						go osSync()
 						return
-					case _ = <-sync.C:
+					case <-sync.C:
 						go osSync()
 						sync.Reset(2 * time.Second)
 					}
@@ -803,7 +803,7 @@ devices:
 				select {
 				case err = <-errCh:
 					require.NotNil(t, err)
-				case _ = <-done:
+				case <-done:
 					close(stopCh)
 					wg.Wait()
 					return

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -135,7 +135,7 @@ func Load(source string) (*Schema, error) {
 	case strings.HasPrefix(source, "http://"):
 	case strings.HasPrefix(source, "https://"):
 	default:
-		if strings.Index(source, "://") < 0 {
+		if !strings.Contains(source, "://") {
 			source, err = filepath.Abs(source)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get JSON schema absolute path for %s: %w",


### PR DESCRIPTION
Make golangci-lint happier:
- remove unnecessary assignments in select statements
- simplify checking of substrings in schema.Load