### PR TITLE
pkg/cdi: add missing error checks in cache

### DIFF
--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -69,7 +69,9 @@ func NewCache(options ...Option) (*Cache, error) {
 		watch:       &watch{},
 	}
 
-	WithSpecDirs(DefaultSpecDirs...)(c)
+	if err := WithSpecDirs(DefaultSpecDirs...)(c); err != nil {
+		return nil, err
+	}
 	c.Lock()
 	defer c.Unlock()
 
@@ -107,9 +109,7 @@ func (c *Cache) configure(options ...Option) error {
 		c.watch.setup(c.specDirs, c.dirErrors)
 		c.watch.start(&c.Mutex, c.refresh, c.dirErrors)
 	}
-	c.refresh()
-
-	return nil
+	return c.refresh()
 }
 
 // Refresh rescans the CDI Spec directories and refreshes the Cache.
@@ -224,7 +224,7 @@ func (c *Cache) InjectDevices(ociSpec *oci.Spec, devices ...string) ([]string, e
 	c.Lock()
 	defer c.Unlock()
 
-	c.refreshIfRequired(false)
+	_, _ = c.refreshIfRequired(false)
 
 	edits := &ContainerEdits{}
 	specs := map[*Spec]struct{}{}
@@ -331,7 +331,7 @@ func (c *Cache) GetDevice(device string) *Device {
 	c.Lock()
 	defer c.Unlock()
 
-	c.refreshIfRequired(false)
+	_, _ = c.refreshIfRequired(false)
 
 	return c.devices[device]
 }
@@ -343,7 +343,7 @@ func (c *Cache) ListDevices() []string {
 	c.Lock()
 	defer c.Unlock()
 
-	c.refreshIfRequired(false)
+	_, _ = c.refreshIfRequired(false)
 
 	for name := range c.devices {
 		devices = append(devices, name)
@@ -360,7 +360,7 @@ func (c *Cache) ListVendors() []string {
 	c.Lock()
 	defer c.Unlock()
 
-	c.refreshIfRequired(false)
+	_, _ = c.refreshIfRequired(false)
 
 	for vendor := range c.specs {
 		vendors = append(vendors, vendor)
@@ -380,7 +380,7 @@ func (c *Cache) ListClasses() []string {
 	c.Lock()
 	defer c.Unlock()
 
-	c.refreshIfRequired(false)
+	_, _ = c.refreshIfRequired(false)
 
 	for _, specs := range c.specs {
 		for _, spec := range specs {
@@ -400,7 +400,7 @@ func (c *Cache) GetVendorSpecs(vendor string) []*Spec {
 	c.Lock()
 	defer c.Unlock()
 
-	c.refreshIfRequired(false)
+	_, _ = c.refreshIfRequired(false)
 
 	return c.specs[vendor]
 }
@@ -535,7 +535,7 @@ func (w *watch) watch(fsw *fsnotify.Watcher, m *sync.Mutex, refresh func() error
 			} else {
 				w.update(dirErrors)
 			}
-			refresh()
+			_ = refresh()
 			m.Unlock()
 
 		case _, ok := <-watch.Errors:


### PR DESCRIPTION
Mostly retain the existing behavior of ignoring errors but using `_` to make golangci-lint happy.