### PR TITLE
chore: omit error checking more explicitly

### DIFF
--- a/pkg/cdi/registry.go
+++ b/pkg/cdi/registry.go
@@ -128,8 +128,9 @@ func GetRegistry(options ...Option) Registry {
 		new = true
 	})
 	if !new && len(options) > 0 {
-		reg.Configure(options...)
-		reg.Refresh()
+		// We don't care about errors here
+		_ = reg.Configure(options...)
+		_ = reg.Refresh()
 	}
 	return reg
 }


### PR DESCRIPTION
Make golangci-lint happy.