### PR TITLE
pkg/cdi: drop unused return value from NewCache function

### DIFF
--- a/cmd/cdi/cmd/cdi-api.go
+++ b/cmd/cdi/cmd/cdi-api.go
@@ -188,9 +188,7 @@ func cdiResolveDevices(ociSpecFiles ...string) error {
 		err        error
 	)
 
-	if cache, err = cdi.NewCache(); err != nil {
-		return fmt.Errorf("failed to create CDI cache instance: %w", err)
-	}
+	cache = cdi.NewCache()
 
 	for _, ociSpecFile := range ociSpecFiles {
 		ociSpec, err = readOCISpec(ociSpecFile)

--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -62,7 +62,7 @@ func WithAutoRefresh(autoRefresh bool) Option {
 // NewCache creates a new CDI Cache. The cache is populated from a set
 // of CDI Spec directories. These can be specified using a WithSpecDirs
 // option. The default set of directories is exposed in DefaultSpecDirs.
-func NewCache(options ...Option) (*Cache, error) {
+func NewCache(options ...Option) *Cache {
 	c := &Cache{
 		autoRefresh: true,
 		watch:       &watch{},
@@ -72,7 +72,8 @@ func NewCache(options ...Option) (*Cache, error) {
 	c.Lock()
 	defer c.Unlock()
 
-	return c, c.configure(options...)
+	c.configure(options...)
+	return c
 }
 
 // Configure applies options to the Cache. Updates and refreshes the
@@ -85,12 +86,14 @@ func (c *Cache) Configure(options ...Option) error {
 	c.Lock()
 	defer c.Unlock()
 
-	return c.configure(options...)
+	c.configure(options...)
+
+	return nil
 }
 
 // Configure the Cache. Start/stop CDI Spec directory watch, refresh
 // the Cache if necessary.
-func (c *Cache) configure(options ...Option) error {
+func (c *Cache) configure(options ...Option) {
 	for _, o := range options {
 		o(c)
 	}
@@ -103,8 +106,6 @@ func (c *Cache) configure(options ...Option) error {
 		c.watch.start(&c.Mutex, c.refresh, c.dirErrors)
 	}
 	c.refresh()
-
-	return nil
 }
 
 // Refresh rescans the CDI Spec directories and refreshes the Cache.

--- a/pkg/cdi/cache_test.go
+++ b/pkg/cdi/cache_test.go
@@ -183,7 +183,7 @@ devices:
 				}
 			}
 
-			cache, err = NewCache(WithSpecDirs(
+			cache = NewCache(WithSpecDirs(
 				filepath.Join(dir, "etc"),
 				filepath.Join(dir, "run")),
 			)
@@ -196,9 +196,6 @@ devices:
 				}
 			}
 
-			if len(tc.errors) == 0 {
-				require.Nil(t, err)
-			}
 			require.NotNil(t, cache)
 
 			for name, dev := range cache.devices {
@@ -557,8 +554,7 @@ devices:
 						if !selfRefresh {
 							opts = append(opts, WithAutoRefresh(false))
 						}
-						cache, err = NewCache(opts...)
-						require.NoError(t, err)
+						cache = NewCache(opts...)
 						require.NotNil(t, cache)
 					} else {
 						err = updateSpecDirs(t, dir, update.etc, update.run)
@@ -789,13 +785,12 @@ devices:
 			dir, err = createSpecDirs(t, tc.updates[0].etc, tc.updates[0].run)
 			require.NoError(t, err)
 
-			cache, err = NewCache(
+			cache = NewCache(
 				WithSpecDirs(
 					filepath.Join(dir, "etc"),
 					filepath.Join(dir, "run"),
 				),
 			)
-			require.NoError(t, err)
 			require.NotNil(t, cache)
 
 			go injector()
@@ -1176,13 +1171,12 @@ devices:
 				t.Errorf("failed to create test directory: %v", err)
 				return
 			}
-			cache, err = NewCache(
+			cache = NewCache(
 				WithSpecDirs(
 					filepath.Join(dir, "etc"),
 					filepath.Join(dir, "run"),
 				),
 			)
-			require.Nil(t, err)
 			require.NotNil(t, cache)
 
 			unresolved, err := cache.InjectDevices(tc.ociSpec, tc.devices...)
@@ -1415,13 +1409,12 @@ devices:
 				t.Errorf("failed to create test directory: %v", err)
 				return
 			}
-			cache, err = NewCache(
+			cache = NewCache(
 				WithSpecDirs(
 					filepath.Join(dir, "etc"),
 					filepath.Join(dir, "run"),
 				),
 			)
-			require.Nil(t, err)
 			require.NotNil(t, cache)
 
 			vendors := cache.ListVendors()
@@ -1571,7 +1564,7 @@ containerEdits:
 			if len(tc.invalid) != 0 {
 				dir, err = createSpecDirs(t, nil, nil)
 				require.NoError(t, err)
-				cache, err = NewCache(
+				cache = NewCache(
 					WithSpecDirs(
 						filepath.Join(dir, "etc"),
 						filepath.Join(dir, "run"),
@@ -1579,7 +1572,6 @@ containerEdits:
 					WithAutoRefresh(false),
 				)
 
-				require.NoError(t, err)
 				require.NotNil(t, cache)
 
 				etc = map[string]string{}
@@ -1604,21 +1596,19 @@ containerEdits:
 			dir, err = createSpecDirs(t, etc, nil)
 			require.NoError(t, err)
 
-			cache, err = NewCache(
+			cache = NewCache(
 				WithSpecDirs(
 					filepath.Join(dir, "etc"),
 				),
 			)
-			require.NoError(t, err)
 			require.NotNil(t, cache)
 
-			other, err = NewCache(
+			other = NewCache(
 				WithSpecDirs(
 					filepath.Join(dir, "run"),
 				),
 				WithAutoRefresh(false),
 			)
-			require.NoError(t, err)
 			require.NotNil(t, other)
 
 			cSpecs := map[string]*cdi.Spec{}
@@ -1796,7 +1786,7 @@ devices:
 
 			dir, err = createSpecDirs(t, nil, nil)
 			require.NoError(t, err)
-			cache, err = NewCache(
+			cache = NewCache(
 				WithSpecDirs(
 					filepath.Join(dir, "etc"),
 					filepath.Join(dir, "run"),
@@ -1804,7 +1794,6 @@ devices:
 				WithAutoRefresh(false),
 			)
 
-			require.NoError(t, err)
 			require.NotNil(t, cache)
 
 			for idx, data := range tc.specs {

--- a/pkg/cdi/registry.go
+++ b/pkg/cdi/registry.go
@@ -124,7 +124,7 @@ var (
 func GetRegistry(options ...Option) Registry {
 	var new bool
 	initOnce.Do(func() {
-		reg, _ = getRegistry(options...)
+		reg = &registry{NewCache(options...)}
 		new = true
 	})
 	if !new && len(options) > 0 {
@@ -143,9 +143,4 @@ func (r *registry) DeviceDB() RegistryDeviceDB {
 // SpecDB returns the registry interface for querying Specs.
 func (r *registry) SpecDB() RegistrySpecDB {
 	return r
-}
-
-func getRegistry(options ...Option) (*registry, error) {
-	c, err := NewCache(options...)
-	return &registry{c}, err
 }


### PR DESCRIPTION
Drop the unused (always nil) error returned by NewCache(). This eliminate some unreachable error paths in the code.

> **NOTE:** This change changes the exported API of "pkg/cdi" package as the prototype of NewCache() changes.