### PR TITLE
pkg/cdi: drop unused return value from Configure methods

### DIFF
--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -78,17 +78,13 @@ func NewCache(options ...Option) *Cache {
 
 // Configure applies options to the Cache. Updates and refreshes the
 // Cache if options have changed.
-func (c *Cache) Configure(options ...Option) error {
-	if len(options) == 0 {
-		return nil
+func (c *Cache) Configure(options ...Option) {
+	if len(options) != 0 {
+		c.Lock()
+		defer c.Unlock()
+
+		c.configure(options...)
 	}
-
-	c.Lock()
-	defer c.Unlock()
-
-	c.configure(options...)
-
-	return nil
 }
 
 // Configure the Cache. Start/stop CDI Spec directory watch, refresh

--- a/pkg/cdi/registry.go
+++ b/pkg/cdi/registry.go
@@ -55,7 +55,7 @@ type Registry interface {
 // GetSpecDirErrors returns any errors related to the configured
 // Spec directories.
 type RegistryRefresher interface {
-	Configure(...Option) error
+	Configure(...Option)
 	Refresh() error
 	GetErrors() map[string][]error
 	GetSpecDirectories() []string
@@ -129,7 +129,7 @@ func GetRegistry(options ...Option) Registry {
 	})
 	if !new && len(options) > 0 {
 		// We don't care about errors here
-		_ = reg.Configure(options...)
+		reg.Configure(options...)
 		_ = reg.Refresh()
 	}
 	return reg


### PR DESCRIPTION
**NOTE:** This change changes the exported API of "pkg/cdi" package as the
prototype of Configure() method of Cache and Registry types changes.

A follow-up on top of #188 