### PR TITLE
Revert NewCache function signature to return an error

### DIFF
--- a/cmd/cdi/cmd/cdi-api.go
+++ b/cmd/cdi/cmd/cdi-api.go
@@ -188,7 +188,7 @@ func cdiResolveDevices(ociSpecFiles ...string) error {
 		err        error
 	)
 
-	cache = cdi.NewCache()
+	cache, _ = cdi.NewCache()
 
 	for _, ociSpecFile := range ociSpecFiles {
 		ociSpec, err = readOCISpec(ociSpecFile)

--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -62,7 +62,19 @@ func WithAutoRefresh(autoRefresh bool) Option {
 // NewCache creates a new CDI Cache. The cache is populated from a set
 // of CDI Spec directories. These can be specified using a WithSpecDirs
 // option. The default set of directories is exposed in DefaultSpecDirs.
-func NewCache(options ...Option) *Cache {
+//
+// Note:
+//
+//	The error returned by this function is always nil and it is only
+//	returned to maintain API compatibility with consumers.
+func NewCache(options ...Option) (*Cache, error) {
+	return newCache(options...), nil
+}
+
+// newCache creates a CDI cache with the supplied options.
+// This function allows testing without handling the nil error returned by the
+// NewCache function.
+func newCache(options ...Option) *Cache {
 	c := &Cache{
 		autoRefresh: true,
 		watch:       &watch{},

--- a/pkg/cdi/cache_test.go
+++ b/pkg/cdi/cache_test.go
@@ -183,7 +183,7 @@ devices:
 				}
 			}
 
-			cache = NewCache(WithSpecDirs(
+			cache = newCache(WithSpecDirs(
 				filepath.Join(dir, "etc"),
 				filepath.Join(dir, "run")),
 			)
@@ -554,7 +554,7 @@ devices:
 						if !selfRefresh {
 							opts = append(opts, WithAutoRefresh(false))
 						}
-						cache = NewCache(opts...)
+						cache = newCache(opts...)
 						require.NotNil(t, cache)
 					} else {
 						err = updateSpecDirs(t, dir, update.etc, update.run)
@@ -785,7 +785,7 @@ devices:
 			dir, err = createSpecDirs(t, tc.updates[0].etc, tc.updates[0].run)
 			require.NoError(t, err)
 
-			cache = NewCache(
+			cache = newCache(
 				WithSpecDirs(
 					filepath.Join(dir, "etc"),
 					filepath.Join(dir, "run"),
@@ -1171,7 +1171,7 @@ devices:
 				t.Errorf("failed to create test directory: %v", err)
 				return
 			}
-			cache = NewCache(
+			cache = newCache(
 				WithSpecDirs(
 					filepath.Join(dir, "etc"),
 					filepath.Join(dir, "run"),
@@ -1409,7 +1409,7 @@ devices:
 				t.Errorf("failed to create test directory: %v", err)
 				return
 			}
-			cache = NewCache(
+			cache = newCache(
 				WithSpecDirs(
 					filepath.Join(dir, "etc"),
 					filepath.Join(dir, "run"),
@@ -1564,7 +1564,7 @@ containerEdits:
 			if len(tc.invalid) != 0 {
 				dir, err = createSpecDirs(t, nil, nil)
 				require.NoError(t, err)
-				cache = NewCache(
+				cache = newCache(
 					WithSpecDirs(
 						filepath.Join(dir, "etc"),
 						filepath.Join(dir, "run"),
@@ -1596,14 +1596,14 @@ containerEdits:
 			dir, err = createSpecDirs(t, etc, nil)
 			require.NoError(t, err)
 
-			cache = NewCache(
+			cache = newCache(
 				WithSpecDirs(
 					filepath.Join(dir, "etc"),
 				),
 			)
 			require.NotNil(t, cache)
 
-			other = NewCache(
+			other = newCache(
 				WithSpecDirs(
 					filepath.Join(dir, "run"),
 				),
@@ -1786,7 +1786,7 @@ devices:
 
 			dir, err = createSpecDirs(t, nil, nil)
 			require.NoError(t, err)
-			cache = NewCache(
+			cache = newCache(
 				WithSpecDirs(
 					filepath.Join(dir, "etc"),
 					filepath.Join(dir, "run"),

--- a/pkg/cdi/registry.go
+++ b/pkg/cdi/registry.go
@@ -124,7 +124,7 @@ var (
 func GetRegistry(options ...Option) Registry {
 	var new bool
 	initOnce.Do(func() {
-		reg = &registry{NewCache(options...)}
+		reg = &registry{newCache(options...)}
 		new = true
 	})
 	if !new && len(options) > 0 {


### PR DESCRIPTION
This change reverts the NewCache function signature to also return an error. This was removed in #188 but does break clients such as moby using the NewCache API.

Instead, a private function is added that returns no error and this is used internally and in tests.