### PR TITLE
Implement default cache with a minimal set of package-level functions.

### DIFF
--- a/cmd/cdi/cmd/monitor.go
+++ b/cmd/cdi/cmd/monitor.go
@@ -121,7 +121,7 @@ func monitorSpecDirs(args ...string) {
 
 			case _ = <-refresh:
 				refresh = nil
-				cdiPrintRegistry(args...)
+				cdiPrintCache(args...)
 			}
 		}
 	}()

--- a/cmd/cdi/cmd/monitor.go
+++ b/cmd/cdi/cmd/monitor.go
@@ -142,7 +142,7 @@ func monitorDirectories(dirs ...string) (*fsnotify.Watcher, error) {
 
 	for _, dir := range dirs {
 		if _, err = os.Stat(dir); err != nil {
-			fmt.Printf("WARNING: failed to stat dir %q, NOT watching it...", dir)
+			fmt.Printf("WARNING: failed to stat dir %q, NOT watching it...\n", dir)
 			continue
 		}
 

--- a/cmd/cdi/cmd/root.go
+++ b/cmd/cdi/cmd/root.go
@@ -72,7 +72,7 @@ func initSpecDirs() {
 			cdi.WithSpecDirs(specDirs...),
 		)
 		if len(cdi.GetRegistry().GetErrors()) > 0 {
-			cdiPrintRegistryErrors()
+			cdiPrintCacheErrors()
 		}
 	}
 }

--- a/pkg/cdi/default-cache.go
+++ b/pkg/cdi/default-cache.go
@@ -1,0 +1,70 @@
+/*
+   Copyright © 2024 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	"sync"
+
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+var (
+	defaultCache   *Cache
+	getDefaultOnce sync.Once
+)
+
+func getOrCreateDefaultCache(options ...Option) (*Cache, bool) {
+	var created bool
+	getDefaultOnce.Do(func() {
+		defaultCache = newCache(options...)
+		created = true
+	})
+	return defaultCache, created
+}
+
+// GetDefaultCache returns the default CDI cache instance.
+func GetDefaultCache() *Cache {
+	cache, _ := getOrCreateDefaultCache()
+	return cache
+}
+
+// Configure applies options to the default CDI cache. Updates and refreshes
+// the default cache if options are not empty.
+func Configure(options ...Option) {
+	cache, created := getOrCreateDefaultCache(options...)
+	if len(options) == 0 || created {
+		return
+	}
+	cache.Configure(options...)
+}
+
+// Refresh explicitly refreshes the default CDI cache instance.
+func Refresh() error {
+	return GetDefaultCache().Refresh()
+}
+
+// InjectDevices injects the given qualified devices to the given OCI Spec.
+// using the default CDI cache instance to resolve devices.
+func InjectDevices(ociSpec *oci.Spec, devices ...string) ([]string, error) {
+	return GetDefaultCache().InjectDevices(ociSpec, devices...)
+}
+
+// GetErrors returns all errors encountered during the last refresh of
+// the default CDI cache instance.
+func GetErrors() map[string][]error {
+	return GetDefaultCache().GetErrors()
+}

--- a/pkg/cdi/default-cache_test.go
+++ b/pkg/cdi/default-cache_test.go
@@ -1,0 +1,417 @@
+/*
+   Copyright © 2021 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultCacheConfigure(t *testing.T) {
+	type specDirs struct {
+		etc map[string]string
+		run map[string]string
+	}
+	type testCase struct {
+		name    string
+		entries specDirs
+		devices []string
+	}
+	for _, tc := range []*testCase{
+		{
+			name: "one CDI Spec",
+			entries: specDirs{
+				run: map[string]string{
+					"vendor1.yaml": `
+cdiVersion: "0.3.0"
+kind:       "vendor1.com/device"
+devices:
+  - name: "dev1"
+    containerEdits:
+      deviceNodes:
+      - path: "/dev/vendor1-dev1"
+        type: b
+        major: 10
+        minor: 1
+`,
+				},
+			},
+			devices: []string{
+				"vendor1.com/device=dev1",
+			},
+		},
+		{
+			name: "two CDI Specs",
+			entries: specDirs{
+				run: map[string]string{
+					"vendor1.yaml": `
+cdiVersion: "0.3.0"
+kind:       "vendor1.com/device"
+devices:
+  - name: "dev1"
+    containerEdits:
+      deviceNodes:
+      - path: "/dev/vendor1-dev1"
+        type: b
+        major: 10
+        minor: 1
+`,
+					"vendor1-other.yaml": `
+cdiVersion: "0.3.0"
+kind:       "vendor1.com/device"
+devices:
+  - name: "dev2"
+    containerEdits:
+      deviceNodes:
+      - path: "/dev/vendor1-dev2"
+        type: b
+        major: 10
+        minor: 2
+`,
+				},
+			},
+			devices: []string{
+				"vendor1.com/device=dev1",
+				"vendor1.com/device=dev2",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				dir   string
+				err   error
+				opts  []Option
+				cache = GetDefaultCache()
+			)
+
+			dir, err = createSpecDirs(t, tc.entries.etc, tc.entries.run)
+			if err != nil {
+				t.Errorf("failed to create test directory: %v", err)
+				return
+			}
+			opts = []Option{
+				WithAutoRefresh(false),
+				WithSpecDirs(
+					filepath.Join(dir, "etc"),
+					filepath.Join(dir, "run"),
+				),
+			}
+			Configure(opts...)
+
+			devices := cache.ListDevices()
+			if len(tc.devices) == 0 {
+				require.True(t, len(devices) == 0)
+			} else {
+				require.Equal(t, tc.devices, devices)
+			}
+		})
+	}
+}
+
+func TestDefaultCacheRefresh(t *testing.T) {
+	type specDirs struct {
+		etc map[string]string
+		run map[string]string
+	}
+	type testCase struct {
+		name    string
+		updates []specDirs
+		errors  []map[string]struct{}
+		devices [][]string
+		devprio []map[string]int
+	}
+	for _, tc := range []*testCase{
+		{
+			name: "empty cache, add one Spec",
+			updates: []specDirs{
+				{},
+				{
+					run: map[string]string{
+						"vendor1.yaml": `
+cdiVersion: "0.3.0"
+kind:       "vendor1.com/device"
+devices:
+  - name: "dev1"
+    containerEdits:
+      deviceNodes:
+      - path: "/dev/vendor1-dev1"
+        type: b
+        major: 10
+        minor: 1
+`,
+					},
+				},
+			},
+			devices: [][]string{
+				nil,
+				{
+					"vendor1.com/device=dev1",
+				},
+			},
+			devprio: []map[string]int{
+				{},
+				{
+					"vendor1.com/device=dev1": 1,
+				},
+			},
+			errors: []map[string]struct{}{
+				{},
+				{},
+			},
+		},
+		{
+			name: "two Specs, remove one",
+			updates: []specDirs{
+				{
+					run: map[string]string{
+						"vendor1.yaml": `
+cdiVersion: "0.3.0"
+kind:       "vendor1.com/device"
+devices:
+  - name: "dev1"
+    containerEdits:
+      deviceNodes:
+      - path: "/dev/vendor1-dev1"
+        type: b
+        major: 10
+        minor: 1
+`,
+						"vendor1-other.yaml": `
+cdiVersion: "0.3.0"
+kind:       "vendor1.com/device"
+devices:
+  - name: "dev2"
+    containerEdits:
+      deviceNodes:
+      - path: "/dev/vendor1-dev2"
+        type: b
+        major: 10
+        minor: 2
+`,
+					},
+				},
+				{
+					run: map[string]string{
+						"vendor1.yaml": "remove",
+					},
+				},
+			},
+			devices: [][]string{
+				{
+					"vendor1.com/device=dev1",
+					"vendor1.com/device=dev2",
+				},
+				{
+					"vendor1.com/device=dev2",
+				},
+			},
+			devprio: []map[string]int{
+				{
+					"vendor1.com/device=dev1": 1,
+					"vendor1.com/device=dev2": 1,
+				},
+				{
+					"vendor1.com/device=dev2": 1,
+				},
+			},
+			errors: []map[string]struct{}{
+				{},
+				{},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				dir   string
+				err   error
+				opts  []Option
+				cache = GetDefaultCache()
+			)
+			for _, selfRefresh := range []bool{false, true} {
+				for idx, update := range tc.updates {
+					if idx == 0 {
+						dir, err = createSpecDirs(t, update.etc, update.run)
+						if err != nil {
+							t.Errorf("failed to create test directory: %v", err)
+							return
+						}
+						opts = []Option{
+							WithAutoRefresh(selfRefresh),
+							WithSpecDirs(
+								filepath.Join(dir, "etc"),
+								filepath.Join(dir, "run"),
+							),
+						}
+						Configure(opts...)
+					} else {
+						err = updateSpecDirs(t, dir, update.etc, update.run)
+						if err != nil {
+							t.Errorf("failed to update test directory: %v", err)
+							return
+						}
+					}
+
+					if !selfRefresh {
+						if idx > 0 { // Configure implies Refresh(), so omit it here
+							err = Refresh()
+							if len(tc.errors[idx]) == 0 {
+								require.Nil(t, err, fmt.Sprintf("unexpected errors: %v", err))
+							} else {
+								require.NotNil(t, err)
+							}
+						}
+					} else {
+						time.Sleep(10 * time.Millisecond)
+					}
+
+					devices := cache.ListDevices()
+					if len(tc.devices[idx]) == 0 {
+						require.True(t, len(devices) == 0)
+					} else {
+						require.Equal(t, tc.devices[idx], devices)
+					}
+
+					for name, prio := range tc.devprio[idx] {
+						dev := cache.GetDevice(name)
+						require.NotNil(t, dev)
+						require.Equal(t, dev.GetSpec().GetPriority(), prio)
+					}
+
+					for _, v := range cache.ListVendors() {
+						for _, spec := range cache.GetVendorSpecs(v) {
+							err := cache.GetSpecErrors(spec)
+							relSpecPath, _ := filepath.Rel(dir, spec.GetPath())
+							_, ok := tc.errors[idx][relSpecPath]
+							require.True(t, (err == nil && !ok) || (err != nil && ok))
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultCacheInjectDevice(t *testing.T) {
+	type specDirs struct {
+		etc map[string]string
+		run map[string]string
+	}
+	type testCase struct {
+		name        string
+		cdiSpecs    specDirs
+		ociSpec     *oci.Spec
+		devices     []string
+		result      *oci.Spec
+		unresolved  []string
+		expectedErr error
+	}
+
+	for _, tc := range []*testCase{
+		{
+			name: "empty OCI Spec, inject one device",
+			cdiSpecs: specDirs{
+				etc: map[string]string{
+					"vendor1.yaml": `
+cdiVersion: "0.3.0"
+kind:       "vendor1.com/device"
+containerEdits:
+  env:
+  - VENDOR1_SPEC_VAR1=VAL1
+devices:
+  - name: "dev1"
+    containerEdits:
+      env:
+      - "VENDOR1_VAR1=VAL1"
+      deviceNodes:
+      - path: "/dev/vendor1-dev1"
+        type: b
+        major: 10
+        minor: 1
+`,
+				},
+			},
+			ociSpec: &oci.Spec{},
+			devices: []string{
+				"vendor1.com/device=dev1",
+			},
+			result: &oci.Spec{
+				Process: &oci.Process{
+					Env: []string{
+						"VENDOR1_SPEC_VAR1=VAL1",
+						"VENDOR1_VAR1=VAL1",
+					},
+				},
+				Linux: &oci.Linux{
+					Devices: []oci.LinuxDevice{
+						{
+							Path:  "/dev/vendor1-dev1",
+							Type:  "b",
+							Major: 10,
+							Minor: 1,
+						},
+					},
+					Resources: &oci.LinuxResources{
+						Devices: []oci.LinuxDeviceCgroup{
+							{
+								Allow:  true,
+								Type:   "b",
+								Major:  int64ptr(10),
+								Minor:  int64ptr(1),
+								Access: "rwm",
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				dir string
+				err error
+			)
+			dir, err = createSpecDirs(t, tc.cdiSpecs.etc, tc.cdiSpecs.run)
+			if err != nil {
+				t.Errorf("failed to create test directory: %v", err)
+				return
+			}
+
+			Configure(
+				WithSpecDirs(
+					filepath.Join(dir, "etc"),
+					filepath.Join(dir, "run"),
+				),
+			)
+
+			unresolved, err := InjectDevices(tc.ociSpec, tc.devices...)
+			if len(tc.unresolved) != 0 {
+				require.NotNil(t, err)
+				require.Equal(t, tc.expectedErr, err)
+				require.Equal(t, tc.unresolved, unresolved)
+				return
+			}
+
+			require.Nil(t, err)
+			require.Equal(t, tc.result, tc.ociSpec)
+		})
+	}
+}

--- a/pkg/cdi/doc.go
+++ b/pkg/cdi/doc.go
@@ -29,6 +29,14 @@
 // the vast majority of CDI consumers need. The API should be usable both
 // by OCI runtime clients and runtime implementations.
 //
+// # Default CDI Cache
+//
+// There is a default CDI cache instance which is always implicitly
+// available and instantiated the first time it is referenced directly
+// or indirectly. The most frequently used cache functions are available
+// as identically named package level functions which operate on the
+// default cache instance.
+//
 // # CDI Registry
 //
 // The primary interface to interact with CDI devices is the Registry. It

--- a/pkg/cdi/doc.go
+++ b/pkg/cdi/doc.go
@@ -35,7 +35,9 @@
 // available and instantiated the first time it is referenced directly
 // or indirectly. The most frequently used cache functions are available
 // as identically named package level functions which operate on the
-// default cache instance.
+// default cache instance. Moreover, the registry also operates on the
+// same default cache. We plan to deprecate the registry and eventually
+// remove it in a future release.
 //
 // # CDI Registry
 //

--- a/pkg/cdi/registry.go
+++ b/pkg/cdi/registry.go
@@ -122,15 +122,12 @@ var (
 // GetRegistry returns the CDI registry. If any options are given, those
 // are applied to the registry.
 func GetRegistry(options ...Option) Registry {
-	var new bool
 	initOnce.Do(func() {
-		reg = &registry{newCache(options...)}
-		new = true
+		reg = &registry{GetDefaultCache()}
 	})
-	if !new && len(options) > 0 {
+	if len(options) > 0 {
 		// We don't care about errors here
 		_ = reg.Configure(options...)
-		_ = reg.Refresh()
 	}
 	return reg
 }


### PR DESCRIPTION
This patch set
  - reintroduces the implicitly available default cache
  - adds a minimal set of package level functions (`Configure()`, `Refresh()`,` InjectDevices()`, `GetErrors()`) which use the default cache
  - adds a `GetDefaultCache()` getter to allow other cache functions to be explicitly called on the default cache
  - updates the registry to use the default cache instead of creating its own instance
  - adds tests for the default cache
  - adds a documentation note about future plans to obsolete and eventually remove  the registry abstraction
  - update the `cdi` test utility to use the default cache