### PR TITLE
Add workflow to mark prs and issues as stale

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,27 @@
+name: Stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "21 4 * * *"
+
+jobs:
+  stale:
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v9
+      with:
+        stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. This issue will be closed in 30 days unless new comments are made or the stale label is removed.'
+        stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. This PR will be closed in 30 days unless new comments are made or the stale label is removed.'
+        stale-issue-label: 'lifecycle/stale'
+        stale-pr-label: 'lifecycle/stale'
+        days-before-stale: 90
+        close-issue-message: 'This issue was automatically closed due to inactivity.'
+        close-pr-message: 'This pull request was automatically closed due to inactivity.' 
+        days-before-issue-close: 30
+        days-before-pr-close: 30
+        remove-stale-when-updated: true
+        operations-per-run: 300


### PR DESCRIPTION
Issues and PRs are marked as stale after 90 days of inactivity and closed after a further 30 days of inactivity.