### PR TITLE
Remove the ToOCI functions from the specs-go package

### DIFF
--- a/pkg/cdi/oci.go
+++ b/pkg/cdi/oci.go
@@ -1,0 +1,65 @@
+/*
+Copyright © 2021 The CDI Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cdi
+
+import (
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// toOCI returns the opencontainers runtime Spec Hook for this Hook.
+func (h *Hook) toOCI() spec.Hook {
+	return spec.Hook{
+		Path:    h.Path,
+		Args:    h.Args,
+		Env:     h.Env,
+		Timeout: h.Timeout,
+	}
+}
+
+// toOCI returns the opencontainers runtime Spec Mount for this Mount.
+func (m *Mount) toOCI() spec.Mount {
+	return spec.Mount{
+		Source:      m.HostPath,
+		Destination: m.ContainerPath,
+		Options:     m.Options,
+		Type:        m.Type,
+	}
+}
+
+// toOCI returns the opencontainers runtime Spec LinuxDevice for this DeviceNode.
+func (d *DeviceNode) toOCI() spec.LinuxDevice {
+	return spec.LinuxDevice{
+		Path:     d.Path,
+		Type:     d.Type,
+		Major:    d.Major,
+		Minor:    d.Minor,
+		FileMode: d.FileMode,
+		UID:      d.UID,
+		GID:      d.GID,
+	}
+}
+
+// toOCI returns the opencontainers runtime Spec LinuxIntelRdt for this IntelRdt config.
+func (i *IntelRdt) toOCI() *spec.LinuxIntelRdt {
+	return &spec.LinuxIntelRdt{
+		ClosID:        i.ClosID,
+		L3CacheSchema: i.L3CacheSchema,
+		MemBwSchema:   i.MemBwSchema,
+		EnableCMT:     i.EnableCMT,
+		EnableMBM:     i.EnableMBM,
+	}
+}

--- a/specs-go/go.mod
+++ b/specs-go/go.mod
@@ -1,5 +1,3 @@
 module tags.cncf.io/container-device-interface/specs-go
 
 go 1.19
-
-require github.com/opencontainers/runtime-spec v1.1.0

--- a/specs-go/go.sum
+++ b/specs-go/go.sum
@@ -1,2 +1,0 @@
-github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bll4AjJ9odEGpg=
-github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=

--- a/specs-go/oci.go
+++ b/specs-go/oci.go
@@ -1,49 +1,56 @@
+/*
+Copyright © 2021 The CDI Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package specs
 
-import (
-	spec "github.com/opencontainers/runtime-spec/specs-go"
-)
+import "errors"
+
+// errDeprecated is returned for the ToOCI functions below.
+// This should provide better guidance for user when migrating from the API
+// below to the APIs provided in the cdi package.
+var errDeprecated = errors.New("deprecated; Use cdi package functions instead")
 
 // ToOCI returns the opencontainers runtime Spec Hook for this Hook.
-func (h *Hook) ToOCI() spec.Hook {
-	return spec.Hook{
-		Path:    h.Path,
-		Args:    h.Args,
-		Env:     h.Env,
-		Timeout: h.Timeout,
-	}
+//
+// Deprecated: This function has been moved to tags.cncf.io/container-device-interface/pkg/cdi.Hook.toOCI
+// and made private.
+func (h *Hook) ToOCI() error {
+	return errDeprecated
 }
 
 // ToOCI returns the opencontainers runtime Spec Mount for this Mount.
-func (m *Mount) ToOCI() spec.Mount {
-	return spec.Mount{
-		Source:      m.HostPath,
-		Destination: m.ContainerPath,
-		Options:     m.Options,
-		Type:        m.Type,
-	}
+//
+// Deprecated: This function has been moved to tags.cncf.io/container-device-interface/pkg/cdi.Mount.toOCI
+// and made private.
+func (m *Mount) ToOCI() error {
+	return errDeprecated
 }
 
 // ToOCI returns the opencontainers runtime Spec LinuxDevice for this DeviceNode.
-func (d *DeviceNode) ToOCI() spec.LinuxDevice {
-	return spec.LinuxDevice{
-		Path:     d.Path,
-		Type:     d.Type,
-		Major:    d.Major,
-		Minor:    d.Minor,
-		FileMode: d.FileMode,
-		UID:      d.UID,
-		GID:      d.GID,
-	}
+//
+// Deprecated: This function has been moved to tags.cncf.io/container-device-interface/pkg/cdi.DeviceNode.toOCI
+// and made private.
+func (d *DeviceNode) ToOCI() error {
+	return errDeprecated
 }
 
 // ToOCI returns the opencontainers runtime Spec LinuxIntelRdt for this IntelRdt config.
-func (i *IntelRdt) ToOCI() *spec.LinuxIntelRdt {
-	return &spec.LinuxIntelRdt{
-		ClosID:        i.ClosID,
-		L3CacheSchema: i.L3CacheSchema,
-		MemBwSchema:   i.MemBwSchema,
-		EnableCMT:     i.EnableCMT,
-		EnableMBM:     i.EnableMBM,
-	}
+//
+// Deprecated: This function has been moved to tags.cncf.io/container-device-interface/pkg/cdi.IntelRdt.toOCI
+// and made private.
+func (i *IntelRdt) ToOCI() error {
+	return errDeprecated
 }


### PR DESCRIPTION
This change removes the ToOCI functions from the specs-go package.
They are implemented as private toOCI functions in the cdi package instead.
This means that there is no dependency on the OCI runtime spec for clients that
only need a CDI spec definition.

**NOTE**: This is a breaking change in that the `ToOCI` functions no longer exist in the `specs-go` module, but the impact of this should be minimal and is worth the removal of the `require github.com/opencontainers/runtime-spec` dependency from the spec definitions.