### PR TITLE
Bump spec version to v0.8.0

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -29,7 +29,8 @@ Released versions of the spec are available as Git tags.
 | v0.6.0 |   | Add `Annotations` field to `Spec` and `Device` specifications |
 |        |   | Allow dots (`.`)  in name segment of `Kind` field. |
 | v0.7.0 |   | Add `IntelRdt`field. |
-| v0.7.0 |   | Add `AdditionalGIDs` to `ContainerEdits` |
+|        |   | Add `AdditionalGIDs` to `ContainerEdits` |
+| v0.8.0 |   | Remove .ToOCI() functions from specs-go package. |
 
 *Note*: The initial release of a **spec** with version `v0.x.0` will be tagged as
 `v0.x.0` with subsequent changes to the API applicable to this version tagged as `v0.x.y`.

--- a/cmd/cdi/go.mod
+++ b/cmd/cdi/go.mod
@@ -22,7 +22,7 @@ require (
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/sys v0.1.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	tags.cncf.io/container-device-interface/specs-go v0.7.0 // indirect
+	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 
 replace tags.cncf.io/container-device-interface => ../..

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	golang.org/x/mod v0.4.2
 	golang.org/x/sys v0.1.0
 	sigs.k8s.io/yaml v1.3.0
-	tags.cncf.io/container-device-interface/specs-go v0.7.0
+	tags.cncf.io/container-device-interface/specs-go v0.8.0
 )
 
 require (

--- a/pkg/cdi/version.go
+++ b/pkg/cdi/version.go
@@ -40,6 +40,7 @@ const (
 	v050 version = "v0.5.0"
 	v060 version = "v0.6.0"
 	v070 version = "v0.7.0"
+	v080 version = "v0.8.0"
 
 	// vEarliest is the earliest supported version of the CDI specification
 	vEarliest version = v030
@@ -56,6 +57,7 @@ var validSpecVersions = requiredVersionMap{
 	v050: requiresV050,
 	v060: requiresV060,
 	v070: requiresV070,
+	v080: requiresV080,
 }
 
 // MinimumRequiredVersion determines the minimum spec version for the input spec.
@@ -118,6 +120,13 @@ func (r requiredVersionMap) requiredVersion(spec *cdi.Spec) version {
 	}
 
 	return minVersion
+}
+
+// requiresV080 returns true if the spec uses v0.8.0 features.
+// Since the v0.8.0 spec bump was due to the removed .ToOCI functions on the
+// spec types, there are explicit spec changes.
+func requiresV080(_ *cdi.Spec) bool {
+	return false
 }
 
 // requiresV070 returns true if the spec uses v0.7.0 features

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -3,7 +3,7 @@ package specs
 import "os"
 
 // CurrentVersion is the current version of the Spec.
-const CurrentVersion = "0.7.0"
+const CurrentVersion = "0.8.0"
 
 // Spec is the base configuration for CDI
 type Spec struct {


### PR DESCRIPTION
This change bumps the CDI Spec version to v0.8.0. 

There were no spec-specific changes in the spec, but the version is being bumped due to there removal of the `.ToOCI()` functions from the spec types.