### PR TITLE
Code cleanup

### DIFF
--- a/cmd/cdi/cmd/cdi-api.go
+++ b/cmd/cdi/cmd/cdi-api.go
@@ -271,7 +271,7 @@ func cdiListSpecs(verbose bool, format string, vendors ...string) {
 		fmt.Printf("Vendor %s:\n", vendor)
 		for _, spec := range cache.GetVendorSpecs(vendor) {
 			cdiPrintSpec(spec, verbose, format, 2)
-			cdiPrintSpecErrors(spec, verbose, 2)
+			cdiPrintSpecErrors(2)
 		}
 	}
 }
@@ -284,7 +284,7 @@ func cdiPrintSpec(spec *cdi.Spec, verbose bool, format string, level int) {
 	}
 }
 
-func cdiPrintSpecErrors(spec *cdi.Spec, verbose bool, level int) {
+func cdiPrintSpecErrors(level int) {
 	var (
 		cache     = cdi.GetDefaultCache()
 		cdiErrors = cache.GetErrors()

--- a/pkg/cdi/cache_test.go
+++ b/pkg/cdi/cache_test.go
@@ -557,7 +557,7 @@ devices:
 						cache = newCache(opts...)
 						require.NotNil(t, cache)
 					} else {
-						err = updateSpecDirs(t, dir, update.etc, update.run)
+						err = updateSpecDirs(dir, update.etc, update.run)
 						if err != nil {
 							t.Errorf("failed to update test directory: %v", err)
 							return
@@ -743,7 +743,7 @@ devices:
 						idx = 0
 					}
 					update := tc.updates[idx]
-					err = updateSpecDirs(t, dir, update.etc, update.run)
+					err = updateSpecDirs(dir, update.etc, update.run)
 					if err != nil {
 						return
 					}
@@ -1851,7 +1851,7 @@ func createSpecDirs(t *testing.T, etc, run map[string]string) (string, error) {
 }
 
 // Update spec directories with new data.
-func updateSpecDirs(t *testing.T, dir string, etc, run map[string]string) error {
+func updateSpecDirs(dir string, etc, run map[string]string) error {
 	updates := map[string]map[string]string{
 		"etc": {},
 		"run": {},
@@ -1869,7 +1869,7 @@ func updateSpecDirs(t *testing.T, dir string, etc, run map[string]string) error 
 			}
 		}
 	}
-	return updateTestDir(t, dir, updates)
+	return updateTestDir(dir, updates)
 }
 
 func int64ptr(v int64) *int64 {

--- a/pkg/cdi/default-cache_test.go
+++ b/pkg/cdi/default-cache_test.go
@@ -263,7 +263,7 @@ devices:
 						}
 						Configure(opts...)
 					} else {
-						err = updateSpecDirs(t, dir, update.etc, update.run)
+						err = updateSpecDirs(dir, update.etc, update.run)
 						if err != nil {
 							t.Errorf("failed to update test directory: %v", err)
 							return

--- a/pkg/cdi/spec-dirs_test.go
+++ b/pkg/cdi/spec-dirs_test.go
@@ -175,9 +175,8 @@ devices:
 				dir, err = mkTestDir(t, map[string]map[string]string{
 					"etc": tc.files,
 				})
-				if err != nil {
-					t.Errorf("failed to populate test directory: %v", err)
-				}
+				require.NoError(t, err, "failed to populate test directory")
+
 				dir = filepath.Join(dir, "etc")
 				success = map[string]struct{}{}
 				failure = map[string]struct{}{}
@@ -186,7 +185,7 @@ devices:
 			}
 
 			dirs := []string{"/no-such-dir", dir}
-			err = scanSpecDirs(dirs, func(path string, prio int, spec *Spec, err error) error {
+			_ = scanSpecDirs(dirs, func(path string, prio int, spec *Spec, err error) error {
 				name := filepath.Base(path)
 				if err != nil {
 					failure[name] = struct{}{}
@@ -220,14 +219,14 @@ func mkTestDir(t *testing.T, dirs map[string]map[string]string) (string, error) 
 		os.RemoveAll(tmp)
 	})
 
-	if err = updateTestDir(t, tmp, dirs); err != nil {
+	if err = updateTestDir(tmp, dirs); err != nil {
 		return "", err
 	}
 
 	return tmp, nil
 }
 
-func updateTestDir(t *testing.T, tmp string, dirs map[string]map[string]string) error {
+func updateTestDir(tmp string, dirs map[string]map[string]string) error {
 	for sub, content := range dirs {
 		dir := filepath.Join(tmp, sub)
 		if err := os.MkdirAll(dir, 0755); err != nil {


### PR DESCRIPTION
Fixed VSCode(gopls check) warnings:

```
$ find . -name \*.go | xargs gopls check
cmd/cdi/cmd/cdi-api.go:287:25-39: unused parameter: spec
cmd/cdi/cmd/cdi-api.go:287:41-53: unused parameter: verbose
pkg/cdi/spec-dirs_test.go:230:20-32: unused parameter: t [windows]
pkg/cdi/spec-dirs_test.go:230:20-32: unused parameter: t
pkg/cdi/spec-dirs_test.go:189:4: ineffectual assignment to err
```