### PR TITLE
Ignore issues / PRs with frozen labels for stale workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -14,13 +14,15 @@ jobs:
     steps:
     - uses: actions/stale@v9
       with:
-        stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. This issue will be closed in 30 days unless new comments are made or the stale label is removed.'
-        stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. This PR will be closed in 30 days unless new comments are made or the stale label is removed.'
+        stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. This issue will be closed in 30 days unless new comments are made or the stale label is removed. To skip these checks, apply the "lifecycle/frozen" label.'
+        stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. This PR will be closed in 30 days unless new comments are made or the stale label is removed. To skip these checks, apply the "lifecycle/frozen" label.'
         stale-issue-label: 'lifecycle/stale'
         stale-pr-label: 'lifecycle/stale'
+        exempt-issue-labels: 'lifecycle/frozen'
+        exempt-pr-labels: 'lifecycle/frozen'
         days-before-stale: 90
         close-issue-message: 'This issue was automatically closed due to inactivity.'
-        close-pr-message: 'This pull request was automatically closed due to inactivity.' 
+        close-pr-message: 'This pull request was automatically closed due to inactivity.'
         days-before-issue-close: 30
         days-before-pr-close: 30
         remove-stale-when-updated: true


### PR DESCRIPTION
Ignore issues / PRs with `lifecycle/frozen` label when marking them as stale / closing them.