### PR TITLE
Ensure that YAML fields are sorted

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,4 +26,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61.0
+          version: v1.64.5

--- a/cmd/cdi/cmd/format.go
+++ b/cmd/cdi/cmd/format.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"sigs.k8s.io/yaml"
+	orderedyaml "gopkg.in/yaml.v2"
 )
 
 func chooseFormat(format string, path string) string {
@@ -46,7 +46,7 @@ func marshalObject(level int, obj interface{}, format string) string {
 	if format == "json" {
 		raw, err = json.MarshalIndent(obj, "", "  ")
 	} else {
-		raw, err = yaml.Marshal(obj)
+		raw, err = orderedyaml.Marshal(obj)
 	}
 
 	if err != nil {

--- a/cmd/cdi/go.mod
+++ b/cmd/cdi/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.1.0
 	github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626
 	github.com/spf13/cobra v1.6.0
+	gopkg.in/yaml.v2 v2.4.0
 	sigs.k8s.io/yaml v1.3.0
 	tags.cncf.io/container-device-interface v0.0.0
 	tags.cncf.io/container-device-interface/schema v0.0.0
@@ -14,7 +15,6 @@ require (
 
 require (
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
-	github.com/opencontainers/selinux v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
@@ -22,7 +22,6 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/mod v0.19.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
 

--- a/cmd/cdi/go.sum
+++ b/cmd/cdi/go.sum
@@ -22,7 +22,6 @@ github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626 h1:
 github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626/go.mod h1:BRHJJd0E+cx42OybVYSgUvZmU0B8P9gZuRXlZUP7TKI=
 github.com/opencontainers/selinux v1.9.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opencontainers/selinux v1.10.0 h1:rAiKF8hTcgLI3w0DHm6i0ylVVcOrlgR1kK99DRLDhyU=
-github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/go.mod
+++ b/go.mod
@@ -8,16 +8,17 @@ require (
 	github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.19.0
+	gopkg.in/yaml.v2 v2.4.0
 	sigs.k8s.io/yaml v1.3.0
 	tags.cncf.io/container-device-interface/specs-go v0.8.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/opencontainers/selinux v1.10.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	golang.org/x/mod v0.19.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,9 @@ github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bl
 github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626 h1:DmNGcqH3WDbV5k8OJ+esPWbqUOX5rMLR2PMvziDMJi0=
 github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626/go.mod h1:BRHJJd0E+cx42OybVYSgUvZmU0B8P9gZuRXlZUP7TKI=
-github.com/opencontainers/selinux v1.9.1 h1:b4VPEF3O5JLZgdTDBmGepaaIbAo0GqoF6EBRq5f/g3Y=
 github.com/opencontainers/selinux v1.9.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
+github.com/opencontainers/selinux v1.10.0 h1:rAiKF8hTcgLI3w0DHm6i0ylVVcOrlgR1kK99DRLDhyU=
+github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=

--- a/pkg/cdi/spec.go
+++ b/pkg/cdi/spec.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	oci "github.com/opencontainers/runtime-spec/specs-go"
+	orderedyaml "gopkg.in/yaml.v2"
 	"sigs.k8s.io/yaml"
 
 	"tags.cncf.io/container-device-interface/internal/validation"
@@ -135,7 +136,7 @@ func (s *Spec) write(overwrite bool) error {
 	}
 
 	if filepath.Ext(s.path) == ".yaml" {
-		data, err = yaml.Marshal(s.Spec)
+		data, err = orderedyaml.Marshal(s.Spec)
 		data = append([]byte("---\n"), data...)
 	} else {
 		data, err = json.Marshal(s.Spec)

--- a/schema/go.sum
+++ b/schema/go.sum
@@ -17,8 +17,8 @@ github.com/opencontainers/runtime-spec v1.1.0 h1:HHUyrt9mwHUjtasSbXSMvs4cyFxh+Bl
 github.com/opencontainers/runtime-spec v1.1.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626 h1:DmNGcqH3WDbV5k8OJ+esPWbqUOX5rMLR2PMvziDMJi0=
 github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626/go.mod h1:BRHJJd0E+cx42OybVYSgUvZmU0B8P9gZuRXlZUP7TKI=
-github.com/opencontainers/selinux v1.9.1 h1:b4VPEF3O5JLZgdTDBmGepaaIbAo0GqoF6EBRq5f/g3Y=
 github.com/opencontainers/selinux v1.9.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
+github.com/opencontainers/selinux v1.10.0 h1:rAiKF8hTcgLI3w0DHm6i0ylVVcOrlgR1kK99DRLDhyU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=

--- a/specs-go/config.go
+++ b/specs-go/config.go
@@ -4,69 +4,69 @@ import "os"
 
 // Spec is the base configuration for CDI
 type Spec struct {
-	Version string `json:"cdiVersion"`
-	Kind    string `json:"kind"`
+	Version string `json:"cdiVersion" yaml:"cdiVersion"`
+	Kind    string `json:"kind"       yaml:"kind"`
 	// Annotations add meta information per CDI spec. Note these are CDI-specific and do not affect container metadata.
 	// Added in v0.6.0.
-	Annotations    map[string]string `json:"annotations,omitempty"`
-	Devices        []Device          `json:"devices"`
-	ContainerEdits ContainerEdits    `json:"containerEdits,omitempty"`
+	Annotations    map[string]string `json:"annotations,omitempty"    yaml:"annotations,omitempty"`
+	Devices        []Device          `json:"devices"                  yaml:"devices"`
+	ContainerEdits ContainerEdits    `json:"containerEdits,omitempty" yaml:"containerEdits,omitempty"`
 }
 
 // Device is a "Device" a container runtime can add to a container
 type Device struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 	// Annotations add meta information per device. Note these are CDI-specific and do not affect container metadata.
 	// Added in v0.6.0.
-	Annotations    map[string]string `json:"annotations,omitempty"`
-	ContainerEdits ContainerEdits    `json:"containerEdits"`
+	Annotations    map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	ContainerEdits ContainerEdits    `json:"containerEdits"        yaml:"containerEdits"`
 }
 
 // ContainerEdits are edits a container runtime must make to the OCI spec to expose the device.
 type ContainerEdits struct {
-	Env            []string      `json:"env,omitempty"`
-	DeviceNodes    []*DeviceNode `json:"deviceNodes,omitempty"`
-	Hooks          []*Hook       `json:"hooks,omitempty"`
-	Mounts         []*Mount      `json:"mounts,omitempty"`
-	IntelRdt       *IntelRdt     `json:"intelRdt,omitempty"`       // Added in v0.7.0
-	AdditionalGIDs []uint32      `json:"additionalGids,omitempty"` // Added in v0.7.0
+	Env            []string      `json:"env,omitempty"            yaml:"env,omitempty"`
+	DeviceNodes    []*DeviceNode `json:"deviceNodes,omitempty"    yaml:"deviceNodes,omitempty"`
+	Hooks          []*Hook       `json:"hooks,omitempty"          yaml:"hooks,omitempty"`
+	Mounts         []*Mount      `json:"mounts,omitempty"         yaml:"mounts,omitempty"`
+	IntelRdt       *IntelRdt     `json:"intelRdt,omitempty"       yaml:"intelRdt,omitempty"`       // Added in v0.7.0
+	AdditionalGIDs []uint32      `json:"additionalGids,omitempty" yaml:"additionalGids,omitempty"` // Added in v0.7.0
 }
 
 // DeviceNode represents a device node that needs to be added to the OCI spec.
 type DeviceNode struct {
-	Path        string       `json:"path"`
-	HostPath    string       `json:"hostPath,omitempty"` // Added in v0.5.0
-	Type        string       `json:"type,omitempty"`
-	Major       int64        `json:"major,omitempty"`
-	Minor       int64        `json:"minor,omitempty"`
-	FileMode    *os.FileMode `json:"fileMode,omitempty"`
-	Permissions string       `json:"permissions,omitempty"`
-	UID         *uint32      `json:"uid,omitempty"`
-	GID         *uint32      `json:"gid,omitempty"`
+	Path        string       `json:"path"                  yaml:"path"`
+	HostPath    string       `json:"hostPath,omitempty"    yaml:"hostPath,omitempty"` // Added in v0.5.0
+	Type        string       `json:"type,omitempty"        yaml:"type,omitempty"`
+	Major       int64        `json:"major,omitempty"       yaml:"major,omitempty"`
+	Minor       int64        `json:"minor,omitempty"       yaml:"minor,omitempty"`
+	FileMode    *os.FileMode `json:"fileMode,omitempty"    yaml:"fileMode,omitempty"`
+	Permissions string       `json:"permissions,omitempty" yaml:"permissions,omitempty"`
+	UID         *uint32      `json:"uid,omitempty"         yaml:"uid,omitempty"`
+	GID         *uint32      `json:"gid,omitempty"         yaml:"gid,omitempty"`
 }
 
 // Mount represents a mount that needs to be added to the OCI spec.
 type Mount struct {
-	HostPath      string   `json:"hostPath"`
-	ContainerPath string   `json:"containerPath"`
-	Options       []string `json:"options,omitempty"`
-	Type          string   `json:"type,omitempty"` // Added in v0.4.0
+	HostPath      string   `json:"hostPath"          yaml:"hostPath"`
+	ContainerPath string   `json:"containerPath"     yaml:"containerPath"`
+	Options       []string `json:"options,omitempty" yaml:"options,omitempty"`
+	Type          string   `json:"type,omitempty"    yaml:"type,omitempty"` // Added in v0.4.0
 }
 
 // Hook represents a hook that needs to be added to the OCI spec.
 type Hook struct {
-	HookName string   `json:"hookName"`
-	Path     string   `json:"path"`
-	Args     []string `json:"args,omitempty"`
-	Env      []string `json:"env,omitempty"`
-	Timeout  *int     `json:"timeout,omitempty"`
+	HookName string   `json:"hookName"          yaml:"hookName"`
+	Path     string   `json:"path"              yaml:"path"`
+	Args     []string `json:"args,omitempty"    yaml:"args,omitempty"`
+	Env      []string `json:"env,omitempty"     yaml:"env,omitempty"`
+	Timeout  *int     `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 }
 
 // IntelRdt describes the Linux IntelRdt parameters to set in the OCI spec.
 type IntelRdt struct {
-	ClosID        string `json:"closID,omitempty"`
-	L3CacheSchema string `json:"l3CacheSchema,omitempty"`
-	MemBwSchema   string `json:"memBwSchema,omitempty"`
-	EnableCMT     bool   `json:"enableCMT,omitempty"`
-	EnableMBM     bool   `json:"enableMBM,omitempty"`
+	ClosID        string `json:"closID,omitempty"        yaml:"closID,omitempty"`
+	L3CacheSchema string `json:"l3CacheSchema,omitempty" yaml:"l3CacheSchema,omitempty"`
+	MemBwSchema   string `json:"memBwSchema,omitempty"   yaml:"memBwSchema,omitempty"`
+	EnableCMT     bool   `json:"enableCMT,omitempty"     yaml:"enableCMT,omitempty"`
+	EnableMBM     bool   `json:"enableMBM,omitempty"     yaml:"enableMBM,omitempty"`
 }


### PR DESCRIPTION
This closes #235 

A sample spec would now output as:
```
---
cdiVersion: v0.3.0
kind: example.com/class
devices: []
containerEdits:
  deviceNodes:
  - path: /dev/foo
```

instead of:
```
---
cdiVersion: v0.3.0
containerEdits:
  deviceNodes:
  - path: /dev/foo
devices: null
kind: example.com/class
```