### PR TITLE
Use existing go version in go mod tidy an verify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ $(BINARIES): bin/%:
 mod-tidy:
 	$(Q)for mod in $$(find . -name go.mod); do \
 	    echo "Tidying $$mod..."; ( \
-	        cd $$(dirname $$mod) && go mod tidy \
+	        cd $$(dirname $$mod) && go mod tidy -go=$$(grep -E "^go\s+[1-9]\.[0-9]+$$" go.mod | sed 's/^go //') \
             ) || exit 1; \
 	done
 


### PR DESCRIPTION
This change ensures that running make mod-tidy doesn't update the go version specified in the mod files.