### PR TITLE
Fix cache refresh on darwin

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,6 +11,8 @@ permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.
   # pull-requests: read
+  # Optional: allow write access to checks to allow the action to annotate code in the PR.
+  checks: write
 
 jobs:
   golangci:

--- a/pkg/cdi/cache_test_darwin.go
+++ b/pkg/cdi/cache_test_darwin.go
@@ -1,5 +1,5 @@
-//go:build !windows && !darwin
-// +build !windows,!darwin
+//go:build darwin
+// +build darwin
 
 /*
    Copyright © 2021 The CDI Authors
@@ -22,5 +22,5 @@ package cdi
 import "syscall"
 
 func osSync() {
-	syscall.Sync()
+	_ = syscall.Sync()
 }

--- a/pkg/cdi/container-edits_test.go
+++ b/pkg/cdi/container-edits_test.go
@@ -17,6 +17,7 @@
 package cdi
 
 import (
+	"runtime"
 	"testing"
 
 	oci "github.com/opencontainers/runtime-spec/specs-go"
@@ -303,6 +304,13 @@ func TestValidateContainerEdits(t *testing.T) {
 }
 
 func TestApplyContainerEdits(t *testing.T) {
+	nullDeviceMajor := int64(1)
+	nullDeviceMinor := int64(3)
+	if runtime.GOOS == "darwin" {
+		nullDeviceMajor = 3
+		nullDeviceMinor = 2
+	}
+
 	type testCase struct {
 		name   string
 		spec   *oci.Spec
@@ -346,8 +354,8 @@ func TestApplyContainerEdits(t *testing.T) {
 						{
 							Path:  "/dev/null",
 							Type:  "c",
-							Major: 1,
-							Minor: 3,
+							Major: nullDeviceMajor,
+							Minor: nullDeviceMinor,
 						},
 					},
 					Resources: &oci.LinuxResources{
@@ -355,8 +363,8 @@ func TestApplyContainerEdits(t *testing.T) {
 							{
 								Allow:  true,
 								Type:   "c",
-								Major:  int64ptr(1),
-								Minor:  int64ptr(3),
+								Major:  &nullDeviceMajor,
+								Minor:  &nullDeviceMinor,
 								Access: "rwm",
 							},
 						},
@@ -389,8 +397,8 @@ func TestApplyContainerEdits(t *testing.T) {
 						{
 							Path:  "/dev/null",
 							Type:  "c",
-							Major: 1,
-							Minor: 3,
+							Major: nullDeviceMajor,
+							Minor: nullDeviceMinor,
 						},
 					},
 					Resources: &oci.LinuxResources{
@@ -398,8 +406,8 @@ func TestApplyContainerEdits(t *testing.T) {
 							{
 								Allow:  true,
 								Type:   "c",
-								Major:  int64ptr(1),
-								Minor:  int64ptr(3),
+								Major:  &nullDeviceMajor,
+								Minor:  &nullDeviceMinor,
 								Access: "rwm",
 							},
 						},

--- a/pkg/cdi/spec.go
+++ b/pkg/cdi/spec.go
@@ -259,7 +259,7 @@ func SetSpecValidator(fn func(*cdi.Spec) error) {
 	specValidator = fn
 }
 
-// validateSpec validates the Spec using the extneral validator.
+// validateSpec validates the Spec using the external validator.
 func validateSpec(raw *cdi.Spec) error {
 	validatorLock.RLock()
 	defer validatorLock.RUnlock()


### PR DESCRIPTION
These changes fix running the unit tests on MacOS and make some minor golangci-lint changes.

The core of the problem is that file creation using `os.Rename` on `darwin` generates `CREATE` events and not `WRITE` events. This change also responds to CREATE events when updating the cache.