### PR TITLE
[RFC] .github: add issue template for releases.

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -1,0 +1,32 @@
+---
+name: New Release
+about: Propose a New Release
+title: Release vX.Y.Z
+labels: ''
+assignees: ''
+---
+
+## Release Process
+
+<!--
+If making adjustments to the checklist, please also file a PR against
+this issue template (.github/ISSUE_TEMPLATE/new-release.md) to update
+it accordingly for future releases.
+-->
+
+- [ ] Create a PR titled `Bump version to vX.Y.Z` including the following changes:
+    - [ ] Change the following to the target version `vX.Y.Z`:
+        - [ ] the `CurrentVersion` in `specs-go/versions.go`,
+        - [ ] the `tags.cncf.io/container-device-interface` version in `schema/go.mod`,
+        - [ ] (*for specification changes only*) the `tags.cncf.io/container-device-interface/specs-go` version in go.mod,
+        - [ ] (*for specification changes only*) the `tags.cncf.io/container-device-interface/specs-go` version in `schema/go.mod`.
+    - [ ] Run `make mod-tidy` to update versions in `cmd/**/go.mod`.
+    - [ ] Run `make mod-verify` to ensure modules are up to date.
+    - [ ] (*for specification changes only*) Add a description to the specification changes in `SPEC.md`.
+    - [ ] (*for specification changes only*) Implement a `requiresV*` function for the target version in `specs-go/versions.go`.
+- [ ] Merge the PR on sufficient approval.
+- [ ] Create a `vX.Y.Z` tag.
+- [ ] (*for specification changes only*) Create a `specs-go/vX.Y.W` tag. (for the first spec version `W` will be the same as `Z`)
+- [ ] Create a GitHub release form the `vX.Y.Z` tag.
+- [ ] (*for specification changes only*) Create a GitHub release from the `specs-go/vX.Y.Z` tag.
+- [ ] Close the release issue.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,25 +1,9 @@
 # Release Process
 
-This document describes the release process for the Container Device Interface.
+The release process is documented in the [issue template for new releases](.github/ISSUE_TEMPLATE/new-release.md).
 
-1. Create an issue titled `Release container-device-interface vx.y.z` with the following content:
-```
-- [ ] Create a PR titled `Bump version to vx.y.z` including the following changes:
-    - [ ] Change the following to the target version `vx.y.z`:
-        - [ ] the `CurrentVersion` in `specs-go/versions.go`,
-        - [ ] the `tags.cncf.io/container-device-interface` version in `schema/go.mod`,
-        - [ ] (*for specification changes only*) the `tags.cncf.io/container-device-interface/specs-go` version in go.mod,
-        - [ ] (*for specification changes only*) the `tags.cncf.io/container-device-interface/specs-go` version in `schema/go.mod`.
-    - [ ] Run `make mod-tidy` to update versions in `cmd/**/go.mod`.
-    - [ ] Run `make mod-verify` to ensure modules are up to date.
-    - [ ] (*for specification changes only*) Add a description to the specification changes in `SPEC.md`.
-    - [ ] (*for specification changes only*) Implement a `requiresV*` function for the target version in `specs-go/versions.go`.
-- [ ] Merge the PR on sufficient approval.
-- [ ] Create a `vx.y.z` tag.
-- [ ] (*for specification changes only*) Create a `specs-go/vx.y.w` tag. (for the first spec version `w` will be the same as `z`)
-- [ ] Create a GitHub release form the `vx.y.z` tag.
-- [ ] (*for specification changes only*) Create a GitHub release from the `specs-go/vx.y.w` tag.
-- [ ] Close the release issue.
-```
-1. Follow the steps as drescribed.
+If you plan or propose a new release:
+
+1. [Open a new issue using the template](https://github.com/cncf-tags/container-device-interface/issues/new?template=new-release.md) for it.
+1. Follow the steps as drescribed in the issue.
 1. If required, create PRs or issues in clients referencing the release issue to update their dependencies.


### PR DESCRIPTION
This PR adds an issue template for tagging new releases. It uses the exact same process and format as the issue used for the `v1.0.0` release.

@elezar @bart0sh Should we add an issue template for new releases to the repository ?
@elezar If you already have it cooking somewhere, feel free to close this in favor of yours.