### PR TITLE
Bump version to v1.0.1

### DIFF
--- a/cmd/cdi/go.mod
+++ b/cmd/cdi/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/spf13/cobra v1.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/yaml v1.4.0
-	tags.cncf.io/container-device-interface v1.0.0
+	tags.cncf.io/container-device-interface v1.0.1
 	tags.cncf.io/container-device-interface/schema v0.0.0
 )
 

--- a/cmd/validate/go.mod
+++ b/cmd/validate/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/mod v0.19.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
-	tags.cncf.io/container-device-interface v1.0.0 // indirect
+	tags.cncf.io/container-device-interface v1.0.1 // indirect
 	tags.cncf.io/container-device-interface/specs-go v1.0.0 // indirect
 )
 

--- a/schema/go.mod
+++ b/schema/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	sigs.k8s.io/yaml v1.4.0
-	tags.cncf.io/container-device-interface v1.0.0
+	tags.cncf.io/container-device-interface v1.0.1
 	tags.cncf.io/container-device-interface/specs-go v1.0.0
 )
 


### PR DESCRIPTION
This bumps the package version for the v1.0.1 release. There are no spec changes.

Requires #262 

Release is tracked in #263 

