### PR TITLE
README: fix hooks example per schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ $ cat > /etc/cdi/vendor.json <<EOF
       {"hostPath": "tmpfs", "containerPath": "/tmp/data", "type": "tmpfs", "options": ["nosuid","strictatime","mode=755","size=65536k"]}
     ],
     "hooks": [
-      {"createContainer": {"path": "/bin/vendor-hook"} },
-      {"startContainer": {"path": "/usr/bin/ldconfig"} }
+      {"hookName": "createContainer", "path": "/bin/vendor-hook" },
+      {"hookName": "startContainer", "path": "/usr/bin/ldconfig" }
     ]
   }
 }


### PR DESCRIPTION
The README example for hooks seems wrong. Interestingly, it's been like that since the very beginning. The schema that was added a bit later has hooks defined differently so update README to match that.