### PR TITLE
.github: cross-build binaries on ubuntu-latest.

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -49,7 +49,7 @@ jobs:
   # Make sure binaries compile on multiple platforms.
   crossbuild:
     name: "Build / Crossbuild Binaries"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Use ubuntu-latest instead of deprecated ubuntu-20.04 for binary cross-build sanity checks.