### PR TITLE
pkg/cdi: drop deprecated RDT fields

### DIFF
--- a/pkg/cdi/oci.go
+++ b/pkg/cdi/oci.go
@@ -56,8 +56,6 @@ func (d *DeviceNode) toOCI() spec.LinuxDevice {
 // toOCI returns the opencontainers runtime Spec LinuxIntelRdt for this IntelRdt config.
 func (i *IntelRdt) toOCI() *spec.LinuxIntelRdt {
 	return &spec.LinuxIntelRdt{
-		ClosID:        i.ClosID,
-		L3CacheSchema: i.L3CacheSchema,
-		MemBwSchema:   i.MemBwSchema,
+		ClosID: i.ClosID,
 	}
 }


### PR DESCRIPTION
Complements 3ebd90eabc93bb2c24a706919528627058680bbd.