### PR TITLE
spec: Fix comment to reference containerEdits field

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -112,7 +112,7 @@ The keywords "must", "must not", "required", "shall", "shall not", "should", "sh
               "key": "value"
             },
 
-            // Same as the below containerSpec field.
+            // Same as the below containerEdits field.
             // This field should only be applied to the Container's OCI spec
             // if that specific device is requested.
             "containerEdits": { ... }


### PR DESCRIPTION
### Purpose
Fix comment in the CDI json spec.

The `containerSpec` field was renamed to `containerEdits` 6 years ago, but there was still a comment referencing the old field.