### PR TITLE
.github: bump golangci-lint to v2.9.0.

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,4 +26,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1.6
+          version: v2.9.0


### PR DESCRIPTION
Bump golangci-lint, should resolve latest CI failures with golang stable now being v1.26.0.