### PR TITLE
Return a wrapped fs.ErrNotExist if no spec directories are defined

### DIFF
--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -321,7 +321,7 @@ func (c *Cache) RemoveSpec(name string) error {
 
 	specDir, _ = c.highestPrioritySpecDir()
 	if specDir == "" {
-		return errors.New("no Spec directories to remove from")
+		return fmt.Errorf("no Spec directories defined: %w", fs.ErrNotExist)
 	}
 
 	path = filepath.Join(specDir, name)

--- a/pkg/cdi/cache_test.go
+++ b/pkg/cdi/cache_test.go
@@ -1839,6 +1839,46 @@ devices:
 	}
 }
 
+func TestRemoveCache(t *testing.T) {
+
+	tmpDir := t.TempDir()
+
+	testCases := []struct {
+		name          string
+		cache         *Cache
+		specToRemove  string
+		expectedError error
+	}{
+		{
+			name: "returns error if cache dirs is empty",
+			cache: &Cache{
+				specDirs: nil,
+			},
+			specToRemove:  "any",
+			expectedError: os.ErrNotExist,
+		},
+		{
+			name: "returns no error if spec does not exist",
+			cache: &Cache{
+				specDirs: []string{tmpDir},
+			},
+			specToRemove:  "non-existent",
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cache.RemoveSpec(tc.specToRemove)
+			if tc.expectedError == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.expectedError)
+			}
+		})
+	}
+}
+
 // Create and populate automatically cleaned up spec directories.
 func createSpecDirs(t *testing.T, etc, run map[string]string) (string, error) {
 	return mkTestDir(t, map[string]map[string]string{


### PR DESCRIPTION
See the discussion here: https://github.com/cncf-tags/container-device-interface/pull/308#discussion_r2823216936

Here we return a wrapped `fs.ErrNotExist` error if there are no spec directories defined instead of a raw error that cannot be queried easily by the caller.