### PR TITLE
Revert to default spec dirs if none are specified

### DIFF
--- a/pkg/cdi/spec-dirs.go
+++ b/pkg/cdi/spec-dirs.go
@@ -43,6 +43,10 @@ var (
 
 // WithSpecDirs returns an option to override the CDI Spec directories.
 func WithSpecDirs(dirs ...string) Option {
+	// If no spec dirs are specified use the default spec dirs.
+	if len(dirs) == 0 {
+		return WithSpecDirs(DefaultSpecDirs...)
+	}
 	return func(c *Cache) {
 		specDirs := make([]string, len(dirs))
 		for i, dir := range dirs {


### PR DESCRIPTION
Instead of accepting an empty list of spec dirs, we explicitly revert to the default spec dirs to ensure that we don't configure a cache with no spec dirs specified.