### PR TITLE
Makefile: add GO_EXTRAFLAGS to go build call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ golangci-lint ci-lint:
 
 $(BINARIES): bin/%:
 	$(Q)echo "Building $@..."
-	$(Q)(cd cmd/$(*) && $(GO_BUILD) -o $(abspath $@) .)
+	$(Q)(cd cmd/$(*) && $(GO_BUILD) $(GO_EXTRAFLAGS) -o $(abspath $@) .)
 
 #
 # go module tidy and verify targets


### PR DESCRIPTION
We may need to specify things like -trimpath, so add $(GO_EXTRAFLAGS) to allow them to be passed from the buildsystem to the Makefile.

This is especially true for reproducible builds in both Debian and OpenEmbedded, golang is very fond of embedding buildpaths into the binary.