### PR TITLE
parser: guard single-character vendor and class names against a slice-bounds panic

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -150,6 +150,9 @@ func validateVendorOrClassName(name string) error {
 	if !IsLetter(rune(name[0])) {
 		return fmt.Errorf("%q, should start with letter", name)
 	}
+	if len(name) == 1 {
+		return nil
+	}
 	for _, c := range string(name[1 : len(name)-1]) {
 		switch {
 		case IsAlphaNumeric(c):

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -41,6 +41,31 @@ func TestQualifiedName(t *testing.T) {
 			isQualified: true,
 		},
 		{
+			// single-character vendor and class (regression: used to panic
+			// with slice bounds out of range [1:0])
+			device:      "a/b=c",
+			vendor:      "a",
+			class:       "b",
+			name:        "c",
+			isQualified: true,
+		},
+		{
+			// single-character class
+			device:      "aa/b=cc",
+			vendor:      "aa",
+			class:       "b",
+			name:        "cc",
+			isQualified: true,
+		},
+		{
+			// single-character vendor
+			device:      "a/bb=cc",
+			vendor:      "a",
+			class:       "bb",
+			name:        "cc",
+			isQualified: true,
+		},
+		{
 			device:      "vendor.com/class=0",
 			vendor:      "vendor.com",
 			class:       "class",


### PR DESCRIPTION
Fixes #320

## What

Add `if len(name) == 1 { return nil }` to `validateVendorOrClassName`, the guard `ValidateDeviceName` already has.

## Why

`validateVendorOrClassName` slices `name[1 : len(name)-1]`, which is `name[1:0]` for a single-character name and panics with `slice bounds out of range [1:0]`. The value reaches this code through `ParseAnnotations` and through on-disk `Spec.validate`, and the library has no recovery on that path, so a malformed name can crash the calling runtime process.

## Tests

Added single-character vendor and class cases to `TestQualifiedName`; these panicked before the fix. With the guard applied, a 45-second fuzz run of about 9.6 million executions over `ParseQualifiedName` found no other crash on this path.
