### PR TITLE
cdi: add resolved edits API

### DIFF
--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -226,8 +226,6 @@ func (c *Cache) refreshIfRequired(force bool) (bool, error) {
 // any of the devices. Might trigger a cache refresh, in which case any
 // errors encountered can be obtained using GetErrors().
 func (c *Cache) InjectDevices(ociSpec *oci.Spec, devices ...string) ([]string, error) {
-	var unresolved []string
-
 	if ociSpec == nil {
 		return devices, fmt.Errorf("can't inject devices, nil OCI Spec")
 	}
@@ -237,23 +235,8 @@ func (c *Cache) InjectDevices(ociSpec *oci.Spec, devices ...string) ([]string, e
 
 	_, _ = c.refreshIfRequired(false) // we record but ignore errors
 
-	edits := &ContainerEdits{}
-	specs := map[*Spec]struct{}{}
-
-	for _, device := range devices {
-		d := c.devices[device]
-		if d == nil {
-			unresolved = append(unresolved, device)
-			continue
-		}
-		if _, ok := specs[d.GetSpec()]; !ok {
-			specs[d.GetSpec()] = struct{}{}
-			edits.Append(d.GetSpec().edits())
-		}
-		edits.Append(d.edits())
-	}
-
-	if unresolved != nil {
+	edits, unresolved := c.collectContainerEdits(devices)
+	if len(unresolved) > 0 {
 		return unresolved, fmt.Errorf("unresolvable CDI devices %s",
 			strings.Join(unresolved, ", "))
 	}
@@ -263,6 +246,59 @@ func (c *Cache) InjectDevices(ociSpec *oci.Spec, devices ...string) ([]string, e
 	}
 
 	return nil, nil
+}
+
+// ResolveEdits resolves the given qualified devices to their effective CDI
+// edits without applying OCI conversion or mutating an OCI Spec.
+func (c *Cache) ResolveEdits(devices ...string) (*ContainerEdits, error) {
+	resolved, err := func() (*ContainerEdits, error) {
+		c.Lock()
+		defer c.Unlock()
+
+		if _, err := c.refreshIfRequired(false); err != nil {
+			return nil, err
+		}
+
+		selected, unresolved := c.collectContainerEdits(devices)
+		if len(unresolved) > 0 {
+			return nil, fmt.Errorf("unresolvable CDI devices %s", strings.Join(unresolved, ", "))
+		}
+
+		return cloneContainerEdits(selected)
+	}()
+	if err != nil {
+		return nil, err
+	}
+	if err := resolved.resolveDeviceNodes(); err != nil {
+		return nil, err
+	}
+
+	return resolved, nil
+}
+
+// collectContainerEdits selects the container edits for devices. The
+// caller must hold the cache lock and is responsible for refresh policy.
+func (c *Cache) collectContainerEdits(devices []string) (*ContainerEdits, []string) {
+	edits := &ContainerEdits{}
+	var unresolved []string
+	specs := map[*Spec]struct{}{}
+
+	for _, qualifiedName := range devices {
+		device := c.devices[qualifiedName]
+		if device == nil {
+			unresolved = append(unresolved, qualifiedName)
+			continue
+		}
+
+		spec := device.GetSpec()
+		if _, ok := specs[spec]; !ok {
+			specs[spec] = struct{}{}
+			edits.Append(spec.edits())
+		}
+		edits.Append(device.edits())
+	}
+
+	return edits, unresolved
 }
 
 // highestPrioritySpecDir returns the Spec directory with highest priority

--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -239,8 +239,6 @@ func (c *Cache) refreshIfRequired(force bool) (bool, error) {
 // any of the devices. Might trigger a cache refresh, in which case any
 // errors encountered can be obtained using GetErrors().
 func (c *Cache) InjectDevices(ociSpec *oci.Spec, devices ...string) ([]string, error) {
-	var unresolved []string
-
 	if ociSpec == nil {
 		return devices, fmt.Errorf("can't inject devices, nil OCI Spec")
 	}
@@ -250,23 +248,8 @@ func (c *Cache) InjectDevices(ociSpec *oci.Spec, devices ...string) ([]string, e
 
 	_, _ = c.refreshIfRequired(false) // we record but ignore errors
 
-	edits := &ContainerEdits{}
-	specs := map[*Spec]struct{}{}
-
-	for _, device := range devices {
-		d := c.devices[device]
-		if d == nil {
-			unresolved = append(unresolved, device)
-			continue
-		}
-		if _, ok := specs[d.GetSpec()]; !ok {
-			specs[d.GetSpec()] = struct{}{}
-			edits.Append(d.GetSpec().edits())
-		}
-		edits.Append(d.edits())
-	}
-
-	if unresolved != nil {
+	edits, unresolved := c.collectContainerEdits(devices)
+	if len(unresolved) > 0 {
 		return unresolved, fmt.Errorf("unresolvable CDI devices %s",
 			strings.Join(unresolved, ", "))
 	}
@@ -276,6 +259,59 @@ func (c *Cache) InjectDevices(ociSpec *oci.Spec, devices ...string) ([]string, e
 	}
 
 	return nil, nil
+}
+
+// ResolveEdits resolves the given qualified devices to their effective CDI
+// edits without applying OCI conversion or mutating an OCI Spec.
+func (c *Cache) ResolveEdits(devices ...string) (*ContainerEdits, error) {
+	resolved, err := func() (*ContainerEdits, error) {
+		c.Lock()
+		defer c.Unlock()
+
+		if _, err := c.refreshIfRequired(false); err != nil {
+			return nil, err
+		}
+
+		selected, unresolved := c.collectContainerEdits(devices)
+		if len(unresolved) > 0 {
+			return nil, fmt.Errorf("unresolvable CDI devices %s", strings.Join(unresolved, ", "))
+		}
+
+		return cloneContainerEdits(selected)
+	}()
+	if err != nil {
+		return nil, err
+	}
+	if err := resolved.resolveDeviceNodes(); err != nil {
+		return nil, err
+	}
+
+	return resolved, nil
+}
+
+// collectContainerEdits selects the container edits for devices. The
+// caller must hold the cache lock and is responsible for refresh policy.
+func (c *Cache) collectContainerEdits(devices []string) (*ContainerEdits, []string) {
+	edits := &ContainerEdits{}
+	var unresolved []string
+	specs := map[*Spec]struct{}{}
+
+	for _, qualifiedName := range devices {
+		device := c.devices[qualifiedName]
+		if device == nil {
+			unresolved = append(unresolved, qualifiedName)
+			continue
+		}
+
+		spec := device.GetSpec()
+		if _, ok := specs[spec]; !ok {
+			specs[spec] = struct{}{}
+			edits.Append(spec.edits())
+		}
+		edits.Append(device.edits())
+	}
+
+	return edits, unresolved
 }
 
 // highestPrioritySpecDir returns the Spec directory with highest priority

--- a/pkg/cdi/container-edits.go
+++ b/pkg/cdi/container-edits.go
@@ -17,6 +17,7 @@
 package cdi
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -68,6 +69,39 @@ var (
 // is injected.
 type ContainerEdits struct {
 	*cdi.ContainerEdits
+}
+
+// cloneContainerEdits returns a deep copy of edits that can be safely modified
+// without changing the source CDI Spec.
+func cloneContainerEdits(edits *ContainerEdits) (*ContainerEdits, error) {
+	clone := &ContainerEdits{ContainerEdits: &cdi.ContainerEdits{}}
+	if edits == nil || edits.ContainerEdits == nil {
+		return clone, nil
+	}
+
+	data, err := json.Marshal(edits.ContainerEdits)
+	if err != nil {
+		return nil, fmt.Errorf("marshal container edits: %w", err)
+	}
+	if err := json.Unmarshal(data, clone.ContainerEdits); err != nil {
+		return nil, fmt.Errorf("unmarshal container edits: %w", err)
+	}
+
+	return clone, nil
+}
+
+// resolveDeviceNodes fills in host-derived device-node fields in edits.
+func (e *ContainerEdits) resolveDeviceNodes() error {
+	if e == nil || e.ContainerEdits == nil {
+		return nil
+	}
+
+	for _, node := range e.DeviceNodes {
+		if err := (&DeviceNode{node}).fillMissingInfo(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Apply edits to the given OCI Spec. Updates the OCI Spec in place.

--- a/pkg/cdi/default-cache.go
+++ b/pkg/cdi/default-cache.go
@@ -63,6 +63,12 @@ func InjectDevices(ociSpec *oci.Spec, devices ...string) ([]string, error) {
 	return GetDefaultCache().InjectDevices(ociSpec, devices...)
 }
 
+// ResolveEdits resolves qualified devices using the default CDI cache without
+// applying OCI conversion or mutating an OCI Spec.
+func ResolveEdits(devices ...string) (*ContainerEdits, error) {
+	return GetDefaultCache().ResolveEdits(devices...)
+}
+
 // GetErrors returns all errors encountered during the last refresh of
 // the default CDI cache instance.
 func GetErrors() map[string][]error {

--- a/pkg/cdi/doc.go
+++ b/pkg/cdi/doc.go
@@ -65,6 +65,13 @@
 //	    return nil
 //	}
 //
+// # Resolving Edits Without OCI Conversion
+//
+// Consumers that apply CDI edits outside an OCI runtime can call ResolveEdits.
+// It returns a complete, detached set of CDI edits in selection order, with
+// host-derived device-node fields resolved, without creating or modifying an
+// OCI Spec. Consumers decide how to apply each returned edit class.
+//
 // # Cache Refresh
 //
 // By default the CDI Spec cache monitors the configured Spec directories

--- a/pkg/cdi/resolved-edits_test.go
+++ b/pkg/cdi/resolved-edits_test.go
@@ -1,0 +1,254 @@
+/*
+   Copyright © 2026 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveEditsReturnsCompleteDetachedEdits(t *testing.T) {
+	dir, err := createSpecDirs(t, map[string]string{
+		"vendor.yaml": `
+cdiVersion: "1.1.0"
+kind: vendor.example/gpu
+containerEdits:
+  env: [SPEC=1]
+  mounts:
+  - hostPath: /spec-host
+    containerPath: /spec-container
+    type: bind
+    options: [rbind, ro]
+  hooks:
+  - hookName: prestart
+    path: /bin/true
+    args: [spec]
+    timeout: 1
+  netDevices:
+  - hostInterfaceName: eth0
+    name: eth0
+  intelRdt:
+    closID: spec
+    l3CacheSchema: L3:0=ffff
+    memBwSchema: MB:0=100
+    schemata: [spec]
+    enableMonitoring: true
+  additionalGids: [0, 1]
+devices:
+- name: gpu0
+  containerEdits:
+    env: [GPU0=1]
+    mounts:
+    - hostPath: /gpu0-host
+      containerPath: /gpu0-container
+      type: tmpfs
+      options: [rw, nosuid]
+    hooks:
+    - hookName: prestart
+      path: /bin/true
+      args: [gpu0]
+      env: [HOOK=gpu0]
+      timeout: 2
+    netDevices:
+    - hostInterfaceName: eth1
+      name: eth1
+    intelRdt:
+      closID: gpu0
+      l3CacheSchema: L3:0=ffff
+      memBwSchema: MB:0=100
+      schemata: [gpu0]
+      enableMonitoring: true
+    additionalGids: [2]
+- name: gpu1
+  containerEdits:
+    env: [GPU1=1]
+    mounts:
+    - hostPath: /gpu1-host
+      containerPath: /gpu1-container
+      options: [ro]
+    hooks:
+    - hookName: prestart
+      path: /bin/true
+      args: [gpu1]
+      timeout: 3
+    netDevices:
+    - hostInterfaceName: eth2
+      name: eth2
+    intelRdt:
+      closID: gpu1
+      schemata: [gpu1]
+    additionalGids: [3]
+`,
+	}, nil)
+	require.NoError(t, err)
+
+	cache := newCache(
+		WithAutoRefresh(false),
+		WithSpecDirs(filepath.Join(dir, "etc")),
+	)
+
+	gpu0 := "vendor.example/gpu=gpu0"
+	gpu1 := "vendor.example/gpu=gpu1"
+	resolved, err := cache.ResolveEdits(gpu0, gpu1, gpu0)
+	require.NoError(t, err)
+	require.Equal(t, []string{"SPEC=1", "GPU0=1", "GPU1=1", "GPU0=1"}, resolved.Env)
+	require.Len(t, resolved.DeviceNodes, 0)
+	require.Len(t, resolved.Mounts, 4)
+	require.Len(t, resolved.Hooks, 4)
+	require.Len(t, resolved.NetDevices, 4)
+	require.Equal(t, []uint32{0, 1, 2, 3, 2}, resolved.AdditionalGIDs)
+	require.Equal(t, "gpu0", resolved.IntelRdt.ClosID)
+	require.Equal(t, "L3:0=ffff", resolved.IntelRdt.L3CacheSchema)
+	require.Equal(t, "MB:0=100", resolved.IntelRdt.MemBwSchema)
+	require.True(t, resolved.IntelRdt.EnableMonitoring)
+	require.Equal(t, []string{"gpu0"}, resolved.IntelRdt.Schemata)
+	require.Equal(t, []string{"rbind", "ro"}, resolved.Mounts[0].Options)
+	require.Equal(t, []string{"rw", "nosuid"}, resolved.Mounts[1].Options)
+	require.Equal(t, []string{"spec", "gpu0", "gpu1", "gpu0"}, []string{
+		resolved.Hooks[0].Args[0],
+		resolved.Hooks[1].Args[0],
+		resolved.Hooks[2].Args[0],
+		resolved.Hooks[3].Args[0],
+	})
+	require.Equal(t, []string{"eth0", "eth1", "eth2", "eth1"}, []string{
+		resolved.NetDevices[0].HostInterfaceName,
+		resolved.NetDevices[1].HostInterfaceName,
+		resolved.NetDevices[2].HostInterfaceName,
+		resolved.NetDevices[3].HostInterfaceName,
+	})
+
+	resolved.Env[1] = "changed"
+	resolved.Mounts[1].Options[0] = "changed"
+	resolved.Hooks[1].Args[0] = "changed"
+	resolved.Hooks[1].Env[0] = "changed"
+	*resolved.Hooks[1].Timeout = 99
+	resolved.NetDevices[1].Name = "changed"
+	resolved.IntelRdt.Schemata[0] = "changed"
+	resolved.AdditionalGIDs[2] = 99
+
+	source := cache.devices[gpu0].ContainerEdits
+	require.Equal(t, "GPU0=1", source.Env[0])
+	require.Equal(t, "rw", source.Mounts[0].Options[0])
+	require.Equal(t, "gpu0", source.Hooks[0].Args[0])
+	require.Equal(t, "HOOK=gpu0", source.Hooks[0].Env[0])
+	require.Equal(t, 2, *source.Hooks[0].Timeout)
+	require.Equal(t, "eth1", source.NetDevices[0].Name)
+	require.Equal(t, "gpu0", source.IntelRdt.Schemata[0])
+	require.Equal(t, uint32(2), source.AdditionalGIDs[0])
+}
+
+func TestResolveEditsEmptyAndUnresolvable(t *testing.T) {
+	cache := newCache(WithAutoRefresh(false))
+
+	empty, err := cache.ResolveEdits()
+	require.NoError(t, err)
+	require.NotNil(t, empty.ContainerEdits)
+
+	resolved, err := cache.ResolveEdits("vendor.example/gpu=missing0", "vendor.example/gpu=missing1")
+	require.Nil(t, resolved)
+	require.EqualError(t, err, "unresolvable CDI devices vendor.example/gpu=missing0, vendor.example/gpu=missing1")
+}
+
+func TestCollectContainerEditsReturnsAggregateInSelectionOrder(t *testing.T) {
+	dir, err := createSpecDirs(t, map[string]string{
+		"vendor.yaml": `
+cdiVersion: "1.1.0"
+kind: vendor.example/gpu
+containerEdits:
+  env: [SPEC=1]
+devices:
+- name: gpu0
+  containerEdits:
+    env: [GPU0=1]
+- name: gpu1
+  containerEdits:
+    env: [GPU1=1]
+`,
+	}, nil)
+	require.NoError(t, err)
+
+	cache := newCache(
+		WithAutoRefresh(false),
+		WithSpecDirs(filepath.Join(dir, "etc")),
+	)
+
+	cache.Lock()
+	defer cache.Unlock()
+	selected, unresolved := cache.collectContainerEdits([]string{
+		"vendor.example/gpu=gpu0",
+		"vendor.example/gpu=gpu1",
+		"vendor.example/gpu=gpu0",
+	})
+	require.Empty(t, unresolved)
+	require.Equal(t, []string{"SPEC=1", "GPU0=1", "GPU1=1", "GPU0=1"}, selected.Env)
+}
+
+func TestResolveEditsPropagatesAutomaticRefreshError(t *testing.T) {
+	dir, err := createSpecDirs(t, map[string]string{
+		"vendor.yaml": `
+cdiVersion: "0.3.0"
+kind: vendor.example/gpu
+devices:
+- name: gpu0
+`,
+	}, nil)
+	require.NoError(t, err)
+
+	cache := newCache(WithSpecDirs(filepath.Join(dir, "etc")))
+	cache.watch.stop()
+	cache.watch = &watch{}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "etc", "vendor.yaml"), []byte("invalid"), 0600))
+
+	resolved, err := cache.ResolveEdits()
+	require.Nil(t, resolved)
+	require.Error(t, err)
+
+	_, err = cache.InjectDevices(&oci.Spec{}, "vendor.example/gpu=gpu0")
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "failed to parse")
+}
+
+func TestInjectDevicesPreservesSpecIntelRdtAfterSelectionRefactor(t *testing.T) {
+	dir, err := createSpecDirs(t, map[string]string{
+		"vendor.yaml": `
+cdiVersion: "0.7.0"
+kind: vendor.example/gpu
+containerEdits:
+  intelRdt:
+    closID: spec
+devices:
+- name: gpu0
+  containerEdits:
+    env: [GPU0=1]
+`,
+	}, nil)
+	require.NoError(t, err)
+
+	cache := newCache(
+		WithAutoRefresh(false),
+		WithSpecDirs(filepath.Join(dir, "etc")),
+	)
+	ociSpec := &oci.Spec{}
+	unresolved, err := cache.InjectDevices(ociSpec, "vendor.example/gpu=gpu0")
+	require.NoError(t, err)
+	require.Empty(t, unresolved)
+	require.Equal(t, "spec", ociSpec.Linux.IntelRdt.ClosID)
+}

--- a/pkg/cdi/resolved-edits_unix_test.go
+++ b/pkg/cdi/resolved-edits_unix_test.go
@@ -1,0 +1,102 @@
+//go:build !windows
+
+/*
+   Copyright © 2026 The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveEditsResolvesDeviceNodesWithoutMutatingCache(t *testing.T) {
+	dir, err := createSpecDirs(t, map[string]string{
+		"vendor.yaml": `
+cdiVersion: "0.5.0"
+kind: vendor.example/gpu
+devices:
+- name: gpu0
+  containerEdits:
+    deviceNodes:
+    - path: /container/null
+      hostPath: /dev/null
+`,
+	}, nil)
+	require.NoError(t, err)
+
+	cache := newCache(
+		WithAutoRefresh(false),
+		WithSpecDirs(filepath.Join(dir, "etc")),
+	)
+	resolved, err := cache.ResolveEdits("vendor.example/gpu=gpu0")
+	require.NoError(t, err)
+	require.Len(t, resolved.DeviceNodes, 1)
+
+	info, err := deviceInfoFromPath("/dev/null")
+	require.NoError(t, err)
+	node := resolved.DeviceNodes[0]
+	require.Equal(t, "/dev/null", node.HostPath)
+	require.Equal(t, charDevice, node.Type)
+	require.Equal(t, info.major, node.Major)
+	require.Equal(t, info.minor, node.Minor)
+	require.NotNil(t, node.FileMode)
+
+	source := cache.devices["vendor.example/gpu=gpu0"].ContainerEdits.DeviceNodes[0]
+	require.Empty(t, source.Type)
+	require.Zero(t, source.Major)
+	require.Zero(t, source.Minor)
+	require.Nil(t, source.FileMode)
+
+	node.Permissions = "r"
+	require.Empty(t, source.Permissions)
+
+	*node.FileMode = 0777
+	require.Nil(t, source.FileMode)
+}
+
+func TestResolveEditsKeepsFullySpecifiedDeviceWithoutHostNode(t *testing.T) {
+	dir, err := createSpecDirs(t, map[string]string{
+		"vendor.yaml": `
+cdiVersion: "0.5.0"
+kind: vendor.example/gpu
+devices:
+- name: gpu0
+  containerEdits:
+    deviceNodes:
+    - path: /container/synthetic
+      hostPath: /does/not/exist
+      type: c
+      major: 123
+      minor: 4
+`,
+	}, nil)
+	require.NoError(t, err)
+
+	cache := newCache(
+		WithAutoRefresh(false),
+		WithSpecDirs(filepath.Join(dir, "etc")),
+	)
+	resolved, err := cache.ResolveEdits("vendor.example/gpu=gpu0")
+	require.NoError(t, err)
+	require.Len(t, resolved.DeviceNodes, 1)
+	require.Equal(t, "/does/not/exist", resolved.DeviceNodes[0].HostPath)
+	require.Equal(t, charDevice, resolved.DeviceNodes[0].Type)
+	require.Equal(t, int64(123), resolved.DeviceNodes[0].Major)
+	require.Equal(t, int64(4), resolved.DeviceNodes[0].Minor)
+}


### PR DESCRIPTION
The idea here is that some CDI consumers may not be operating on an OCI container (think sandbox wrappers), but it would be silly to have them all re-implement the code that maps the specfile to the running host when the reference implementations are already doing all of that work.

See also: https://github.com/cncf-tags/container-device-interface-rs/pull/101 