### PR TITLE
schema: make use of additionalProperties=false

### DIFF
--- a/schema/defs.json
+++ b/schema/defs.json
@@ -67,7 +67,8 @@
             },
             "required": [
                 "path"
-            ]
+            ],
+            "additionalProperties": false
         },
         "Mount": {
             "type": "object",
@@ -88,7 +89,8 @@
             "required": [
                 "hostPath",
                 "containerPath"
-            ]
+            ],
+            "additionalProperties": false
         },
         "Hook": {
             "type": "object",
@@ -112,7 +114,8 @@
             "required": [
                 "hookName",
                 "path"
-            ]
+            ],
+            "additionalProperties": false
         },
         "LinuxNetDevice": {
             "type": "object",
@@ -127,7 +130,8 @@
             "required": [
                 "hostInterfaceName",
                 "name"
-            ]
+            ],
+            "additionalProperties": false
         },
         "containerEdits": {
             "type": "object",
@@ -180,7 +184,8 @@
                         "enableMonitoring": {
                             "type": "boolean"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "additionalGids": {
                     "type": "array",
@@ -188,7 +193,8 @@
                         "$ref": "#/definitions/uint32"
                     }
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "annotations": {
             "$ref": "#/definitions/mapStringString"

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -33,7 +33,8 @@
                 "required": [
                     "name",
                     "containerEdits"
-                ]
+                ],
+                "additionalProperties": false
             }
         }
     },
@@ -41,5 +42,6 @@
         "cdiVersion",
         "kind",
         "devices"
-    ]
+    ],
+    "additionalProperties": false
 }


### PR DESCRIPTION
Supplement the schema validation with setting additionalProperties=false to relevant fields. This prevents unknown fields from passing validation, corresponding to strict unmarshalling of specs.