### PR TITLE
cmd/cdi: respect the --spec-dirs flag

### DIFF
--- a/cmd/cdi/cmd/cdi-api.go
+++ b/cmd/cdi/cmd/cdi-api.go
@@ -182,14 +182,13 @@ func cdiInjectDevices(format string, ociSpec *oci.Spec, patterns []string) error
 
 func cdiResolveDevices(ociSpecFiles ...string) error {
 	var (
-		cache      *cdi.Cache
+		cache      = cdi.GetDefaultCache()
 		ociSpec    *oci.Spec
 		devices    []string
 		unresolved []string
 		err        error
 	)
 
-	cache, _ = cdi.NewCache()
 
 	for _, ociSpecFile := range ociSpecFiles {
 		ociSpec, err = readOCISpec(ociSpecFile)

--- a/cmd/cdi/cmd/root.go
+++ b/cmd/cdi/cmd/root.go
@@ -67,15 +67,8 @@ func initSpecDirs() {
 	cdi.SetSpecValidator(schema.WithSchema(s))
 
 	if len(specDirs) > 0 {
-		cache, err := cdi.NewCache(
-			cdi.WithSpecDirs(specDirs...),
-		)
-		if err != nil {
-			fmt.Printf("failed to create CDI cache: %v\n", err)
-			os.Exit(1)
-		}
-		if len(cache.GetErrors()) > 0 {
-			cdiPrintCacheErrors()
+		if err := cdi.Configure(cdi.WithSpecDirs(specDirs...)); err != nil {
+			fmt.Printf("failed to configure CDI cache: %v\n", err)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
Also, don't bail out on spec dir errors – behave similarly to default spec dirs.