### PR TITLE
schema: make validation error private

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -58,9 +58,9 @@ func (s *Schema) Validate(spec *cdi.Spec) error {
 	return s.ValidateType(spec)
 }
 
-// Error wraps a JSON validation result.
-type Error struct {
-	Result *schema.Result
+// validationError wraps a JSON validation result.
+type validationError struct {
+	result *schema.Result
 }
 
 // Set sets the default validating JSON schema.
@@ -239,7 +239,7 @@ func (s *Schema) validate(doc schema.JSONLoader) error {
 		return nil
 	}
 
-	return &Error{Result: docErr}
+	return &validationError{result: docErr}
 }
 
 type schemaContents map[string]interface{}
@@ -337,14 +337,14 @@ func (s *Schema) validateContents(any map[string]interface{}) error {
 	return nil
 }
 
-// Error returns the given Result's errors as a single error string.
-func (e *Error) Error() string {
-	if e == nil || e.Result == nil || e.Result.Valid() {
+// validationError returns the given result's errors as a single error string.
+func (e *validationError) Error() string {
+	if e == nil || e.result == nil || e.result.Valid() {
 		return ""
 	}
 
 	errs := []error{}
-	for _, err := range e.Result.Errors() {
+	for _, err := range e.result.Errors() {
 		errs = append(errs, fmt.Errorf("%v", err))
 	}
 


### PR DESCRIPTION
- relates to https://github.com/cncf-tags/container-device-interface/pull/54

The exported Error type exposes gojsonschema.Result, leaking details of the JSON schema validator implementation, as well as the dependency itself, into the public API.

Error was introduced in 711b138f81fa71144c3dcf76ed78f8fb957a90da as part of PR 54. Neither the commit nor the related PR discussion indicate an intent for the validator result or the Error type itself to form part of the public API; it appears to have only been used internally to carry validation details until the error was formatted.

There are no known external consumers of the schema package at all, let alone consumers depending on the exported Error type or its Result field.

Make the validation error implementation private. This keeps the public API independent of the JSON schema validator and allows that implementation and dependency to be replaced without affecting callers.