### PR TITLE
schema, validation: minor fixes and modernization

### DIFF
--- a/cmd/cdi/cmd/format.go
+++ b/cmd/cdi/cmd/format.go
@@ -36,11 +36,11 @@ func chooseFormat(format string, path string) string {
 	return format
 }
 
-func marshalObject(level int, obj interface{}, format string) string {
+func marshalObject(level int, obj any, format string) string {
 	var (
 		raw []byte
 		err error
-		out string
+		out strings.Builder
 	)
 
 	if format == "json" {
@@ -54,10 +54,10 @@ func marshalObject(level int, obj interface{}, format string) string {
 	}
 
 	for _, line := range strings.Split(strings.TrimSuffix(string(raw), "\n"), "\n") {
-		out += indent(level) + line + "\n"
+		out.WriteString(indent(level) + line + "\n")
 	}
 
-	return out
+	return out.String()
 }
 
 func indent(level int) string {

--- a/internal/validation/validate.go
+++ b/internal/validation/validate.go
@@ -18,39 +18,29 @@ package validation
 
 import (
 	"fmt"
-	"strings"
 
 	"tags.cncf.io/container-device-interface/internal/validation/k8s"
 )
 
 // ValidateSpecAnnotations checks whether spec annotations are valid.
-func ValidateSpecAnnotations(name string, any interface{}) error {
-	if any == nil {
+func ValidateSpecAnnotations(name string, specAnnotations any) error {
+	values, ok := specAnnotations.(map[string]any)
+	if !ok {
 		return nil
 	}
 
-	switch v := any.(type) {
-	case map[string]interface{}:
-		annotations := make(map[string]string)
-		for k, v := range v {
-			if s, ok := v.(string); ok {
-				annotations[k] = s
-			} else {
-				return fmt.Errorf("invalid annotation %v.%v; %v is not a string", name, k, any)
-			}
+	annotations := make(map[string]string, len(values))
+	for k, v := range values {
+		s, ok := v.(string)
+		if !ok {
+			return fmt.Errorf("invalid annotation %v.%v; %v is not a string", name, k, v)
 		}
-		return validateSpecAnnotations(name, annotations)
+		annotations[k] = s
 	}
 
-	return nil
-}
-
-// validateSpecAnnotations checks whether spec annotations are valid.
-func validateSpecAnnotations(name string, annotations map[string]string) error {
 	path := "annotations"
 	if name != "" {
-		path = strings.Join([]string{name, path}, ".")
+		path = name + "." + path
 	}
-
 	return k8s.ValidateAnnotations(annotations, path)
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"sigs.k8s.io/yaml"
 
@@ -35,6 +36,13 @@ import (
 	"tags.cncf.io/container-device-interface/internal/validation"
 	cdi "tags.cncf.io/container-device-interface/specs-go"
 )
+
+// currently loaded schema, builtin by default
+var current atomic.Pointer[Schema]
+
+func init() {
+	current.Store(BuiltinSchema())
+}
 
 const (
 	// BuiltinSchemaName names the builtin schema for Load()/Set().
@@ -66,12 +74,15 @@ type Error struct {
 
 // Set sets the default validating JSON schema.
 func Set(s *Schema) {
-	current = s
+	if s == nil {
+		s = NopSchema()
+	}
+	current.Store(s)
 }
 
 // Get returns the active validating JSON schema.
 func Get() *Schema {
-	return current
+	return current.Load()
 }
 
 // BuiltinSchema returns the builtin schema if we have a valid one. Otherwise
@@ -101,27 +112,27 @@ func NopSchema() *Schema {
 
 // ReadAndValidate all data from the given reader, using the active schema for validation.
 func ReadAndValidate(r io.Reader) ([]byte, error) {
-	return current.ReadAndValidate(r)
+	return Get().ReadAndValidate(r)
 }
 
 // ValidateReader validates the data read from an io.Reader against the active schema.
 func ValidateReader(r io.Reader) error {
-	return current.ValidateReader(r)
+	return Get().ValidateReader(r)
 }
 
 // ValidateData validates the given JSON document against the active schema.
 func ValidateData(data []byte) error {
-	return current.ValidateData(data)
+	return Get().ValidateData(data)
 }
 
 // ValidateFile validates the given JSON file against the active schema.
 func ValidateFile(path string) error {
-	return current.ValidateFile(path)
+	return Get().ValidateFile(path)
 }
 
 // ValidateType validates a go object against the schema.
 func ValidateType(obj any) error {
-	return current.ValidateType(obj)
+	return Get().ValidateType(obj)
 }
 
 // Load the given JSON Schema.
@@ -349,9 +360,6 @@ func (e *Error) Error() string {
 
 	return ""
 }
-
-// currently loaded schema, builtin by default
-var current = builtinSchema()
 
 //go:embed *.json
 var builtinFS embed.FS

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -122,7 +122,7 @@ func ValidateFile(path string) error {
 }
 
 // ValidateType validates a go object against the schema.
-func ValidateType(obj interface{}) error {
+func ValidateType(obj any) error {
 	return current.ValidateType(obj)
 }
 
@@ -183,7 +183,7 @@ func (s *Schema) ValidateReader(r io.Reader) error {
 
 // ValidateData validates the given JSON data against the schema.
 func (s *Schema) ValidateData(data []byte) error {
-	var schemaData map[string]interface{}
+	var schemaData map[string]any
 	if !bytes.HasPrefix(bytes.TrimSpace(data), []byte{'{'}) {
 		var err error
 		err = yaml.Unmarshal(data, &schemaData)
@@ -217,7 +217,7 @@ func (s *Schema) ValidateFile(path string) error {
 }
 
 // ValidateType validates a go object against the schema.
-func (s *Schema) ValidateType(obj interface{}) error {
+func (s *Schema) ValidateType(obj any) error {
 	l := schema.NewGoLoader(obj)
 	return s.validate(l)
 }
@@ -239,18 +239,18 @@ func (s *Schema) validate(doc schema.JSONLoader) error {
 	return &Error{Result: docErr}
 }
 
-type schemaContents map[string]interface{}
+type schemaContents map[string]any
 
-func asSchemaContents(i interface{}) (schemaContents, error) {
+func asSchemaContents(i any) (schemaContents, error) {
 	if i == nil {
 		return nil, nil
 	}
 
-	if c, ok := i.(map[string]interface{}); ok {
+	if c, ok := i.(map[string]any); ok {
 		return schemaContents(c), nil
 	}
 
-	return nil, fmt.Errorf("expected map[string]interface{} but got %T", i)
+	return nil, fmt.Errorf("expected map[string]any but got %T", i)
 }
 
 func (c schemaContents) getFieldAsString(key string) (string, bool) {
@@ -265,12 +265,12 @@ func (c schemaContents) getFieldAsString(key string) (string, bool) {
 	return "", false
 }
 
-func (c schemaContents) getAnnotations() (map[string]interface{}, bool) {
+func (c schemaContents) getAnnotations() (map[string]any, bool) {
 	if c == nil {
 		return nil, false
 	}
 	if v, ok := c["annotations"]; ok {
-		if annotations, ok := v.(map[string]interface{}); ok {
+		if annotations, ok := v.(map[string]any); ok {
 			return annotations, true
 		}
 	}
@@ -286,7 +286,7 @@ func (c schemaContents) getDevices() ([]schemaContents, error) {
 		return nil, nil
 	}
 
-	devices, ok := devicesIfc.([]interface{})
+	devices, ok := devicesIfc.([]any)
 	if !ok {
 		return nil, nil
 	}
@@ -304,7 +304,7 @@ func (c schemaContents) getDevices() ([]schemaContents, error) {
 }
 
 // validateContents performs additional validation against the schema contents.
-func (s *Schema) validateContents(data map[string]interface{}) error {
+func (s *Schema) validateContents(data map[string]any) error {
 	if data == nil || s == nil {
 		return nil
 	}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"sigs.k8s.io/yaml"
 
@@ -76,10 +77,10 @@ func Get() *Schema {
 // BuiltinSchema returns the builtin schema if we have a valid one. Otherwise
 // it falls back to NopSchema().
 func BuiltinSchema() *Schema {
-	if builtin != nil {
-		return builtin
-	}
+	return builtinSchema()
+}
 
+var builtinSchema = sync.OnceValue(func() *Schema {
 	s, err := schema.NewSchema(
 		schema.NewReferenceLoaderFileSystem(
 			builtinSchemaFile,
@@ -87,14 +88,11 @@ func BuiltinSchema() *Schema {
 		),
 	)
 
-	if err == nil {
-		builtin = &Schema{schema: s}
-	} else {
-		builtin = NopSchema()
+	if err != nil {
+		return NopSchema()
 	}
-
-	return builtin
-}
+	return &Schema{schema: s}
+})
 
 // NopSchema returns an validating JSON Schema that does no real validation.
 func NopSchema() *Schema {
@@ -352,12 +350,8 @@ func (e *Error) Error() string {
 	return ""
 }
 
-var (
-	// our builtin schema
-	builtin *Schema
-	// currently loaded schema, builtin by default
-	current = BuiltinSchema()
-)
+// currently loaded schema, builtin by default
+var current = builtinSchema()
 
 //go:embed *.json
 var builtinFS embed.FS

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -183,17 +183,14 @@ func (s *Schema) ValidateReader(r io.Reader) error {
 
 // ValidateData validates the given JSON data against the schema.
 func (s *Schema) ValidateData(data []byte) error {
-	var (
-		any map[string]interface{}
-		err error
-	)
-
+	var schemaData map[string]interface{}
 	if !bytes.HasPrefix(bytes.TrimSpace(data), []byte{'{'}) {
-		err = yaml.Unmarshal(data, &any)
+		var err error
+		err = yaml.Unmarshal(data, &schemaData)
 		if err != nil {
 			return fmt.Errorf("failed to YAML unmarshal data for validation: %w", err)
 		}
-		data, err = json.Marshal(any)
+		data, err = json.Marshal(schemaData)
 		if err != nil {
 			return fmt.Errorf("failed to JSON remarshal data for validation: %w", err)
 		}
@@ -203,7 +200,7 @@ func (s *Schema) ValidateData(data []byte) error {
 		return err
 	}
 
-	return s.validateContents(any)
+	return s.validateContents(schemaData)
 }
 
 // ValidateFile validates the given JSON file against the schema.
@@ -260,8 +257,8 @@ func (c schemaContents) getFieldAsString(key string) (string, bool) {
 	if c == nil {
 		return "", false
 	}
-	if value, ok := c[key]; ok {
-		if value, ok := value.(string); ok {
+	if v, ok := c[key]; ok {
+		if value, ok := v.(string); ok {
 			return value, true
 		}
 	}
@@ -272,8 +269,8 @@ func (c schemaContents) getAnnotations() (map[string]interface{}, bool) {
 	if c == nil {
 		return nil, false
 	}
-	if annotations, ok := c["annotations"]; ok {
-		if annotations, ok := annotations.(map[string]interface{}); ok {
+	if v, ok := c["annotations"]; ok {
+		if annotations, ok := v.(map[string]interface{}); ok {
 			return annotations, true
 		}
 	}
@@ -296,23 +293,23 @@ func (c schemaContents) getDevices() ([]schemaContents, error) {
 
 	var deviceContents []schemaContents
 	for _, device := range devices {
-		c, err := asSchemaContents(device)
+		sc, err := asSchemaContents(device)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse device: %w", err)
 		}
-		deviceContents = append(deviceContents, c)
+		deviceContents = append(deviceContents, sc)
 	}
 
 	return deviceContents, nil
 }
 
 // validateContents performs additional validation against the schema contents.
-func (s *Schema) validateContents(any map[string]interface{}) error {
-	if any == nil || s == nil {
+func (s *Schema) validateContents(data map[string]interface{}) error {
+	if data == nil || s == nil {
 		return nil
 	}
 
-	contents := schemaContents(any)
+	contents := schemaContents(data)
 
 	if specAnnotations, ok := contents.getAnnotations(); ok {
 		if err := validation.ValidateSpecAnnotations("", specAnnotations); err != nil {


### PR DESCRIPTION
### schema: rename vars that collided

### chore: go fix code

Automated modernizing code with `go fix -mod=readonly -all ./...`

### schema: implement BuiltinSchema with sync.OnceValue

Replace the hand-crafted lazy initialization of the built-in schema with
sync.OnceValue.

This simplifies the implementation and makes concurrent calls to
BuiltinSchema safe without requiring explicit synchronization.


### schema: synchronize access to the active schema

Set can replace the active schema while it is being used for validation,
causing a data race on current.

Use an atomic.Pointer for current, and use Get for reads, so changing the
active schema is safe while validations are running concurrently.
