### PR TITLE
specs-go: remove x/mod semver dependency

### DIFF
--- a/cmd/cdi/go.mod
+++ b/cmd/cdi/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/mod v0.19.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/cmd/cdi/go.sum
+++ b/cmd/cdi/go.sum
@@ -26,8 +26,6 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
-golang.org/x/mod v0.19.0 h1:fEdghXQSo20giMthA7cd28ZC+jts4amQ3YMXiP5oMQ8=
-golang.org/x/mod v0.19.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
 golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/cmd/validate/go.mod
+++ b/cmd/validate/go.mod
@@ -6,7 +6,6 @@ require tags.cncf.io/container-device-interface/schema v0.0.0
 
 require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 // indirect
-	golang.org/x/mod v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 	tags.cncf.io/container-device-interface v1.1.0 // indirect

--- a/cmd/validate/go.sum
+++ b/cmd/validate/go.sum
@@ -16,8 +16,6 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
-golang.org/x/mod v0.19.0 h1:fEdghXQSo20giMthA7cd28ZC+jts4amQ3YMXiP5oMQ8=
-golang.org/x/mod v0.19.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
 golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/mod v0.19.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
-golang.org/x/mod v0.19.0 h1:fEdghXQSo20giMthA7cd28ZC+jts4amQ3YMXiP5oMQ8=
-golang.org/x/mod v0.19.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
 golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/schema/go.mod
+++ b/schema/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
-	golang.org/x/mod v0.19.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/schema/go.sum
+++ b/schema/go.sum
@@ -18,8 +18,6 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
-golang.org/x/mod v0.19.0 h1:fEdghXQSo20giMthA7cd28ZC+jts4amQ3YMXiP5oMQ8=
-golang.org/x/mod v0.19.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
 golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/specs-go/go.mod
+++ b/specs-go/go.mod
@@ -1,5 +1,3 @@
 module tags.cncf.io/container-device-interface/specs-go
 
 go 1.19
-
-require golang.org/x/mod v0.19.0

--- a/specs-go/go.sum
+++ b/specs-go/go.sum
@@ -1,2 +1,0 @@
-golang.org/x/mod v0.19.0 h1:fEdghXQSo20giMthA7cd28ZC+jts4amQ3YMXiP5oMQ8=
-golang.org/x/mod v0.19.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -19,47 +19,46 @@ package specs
 import (
 	"fmt"
 	"strings"
-
-	"golang.org/x/mod/semver"
 )
 
+// CurrentVersion is the current version of the Spec.
+const CurrentVersion = "1.1.0"
+
 const (
-	// CurrentVersion is the current version of the Spec.
-	CurrentVersion = "1.1.0"
-
-	// vCurrent is the current version as a semver-comparable type
-	vCurrent version = "v" + CurrentVersion
-
 	// These represent the released versions of the CDI specification
-	v010 version = "v0.1.0"
-	v020 version = "v0.2.0"
-	v030 version = "v0.3.0"
-	v040 version = "v0.4.0"
-	v050 version = "v0.5.0"
-	v060 version = "v0.6.0"
-	v070 version = "v0.7.0"
-	v080 version = "v0.8.0"
-	v100 version = "v1.0.0"
-	v110 version = "v1.1.0"
+	v010 version = "0.1.0"
+	v020 version = "0.2.0"
+	v030 version = "0.3.0"
+	v040 version = "0.4.0"
+	v050 version = "0.5.0"
+	v060 version = "0.6.0"
+	v070 version = "0.7.0"
+	v080 version = "0.8.0"
+	v100 version = "1.0.0"
+	v110 version = "1.1.0"
 
 	// vEarliest is the earliest supported version of the CDI specification
 	vEarliest version = v030
 )
 
-// validSpecVersions stores a map of spec versions to functions to check the required versions.
+// validSpecVersions stores the known spec versions in newest-to-oldest order,
+// together with functions to check whether a version is required.
 // Adding new fields / spec versions requires that a `requiredFunc` be implemented and
-// this map be updated.
-var validSpecVersions = requiredVersionMap{
-	v010: nil,
-	v020: nil,
-	v030: nil,
-	v040: requiresV040,
-	v050: requiresV050,
-	v060: requiresV060,
-	v070: requiresV070,
-	v080: requiresV080,
-	v100: requiresV100,
-	v110: requiresV110,
+// this list be updated.
+var validSpecVersions = []struct {
+	version    version
+	isRequired requiredFunc
+}{
+	{v110, requiresV110},
+	{v100, requiresV100},
+	{v080, requiresV080},
+	{v070, requiresV070},
+	{v060, requiresV060},
+	{v050, requiresV050},
+	{v040, requiresV040},
+	{v030, nil},
+	{v020, nil},
+	{v010, nil},
 }
 
 // ValidateVersion checks whether the specified spec version is valid.
@@ -67,14 +66,15 @@ var validSpecVersions = requiredVersionMap{
 // the spec is inspected to determine whether the features used are available in specified
 // version.
 func ValidateVersion(spec *Spec) error {
-	if !validSpecVersions.isValidVersion(spec.Version) {
+	specVersion := newVersion(spec.Version)
+	if !isValidVersion(specVersion) {
 		return fmt.Errorf("invalid version %q", spec.Version)
 	}
 	minVersion, err := MinimumRequiredVersion(spec)
 	if err != nil {
 		return fmt.Errorf("could not determine minimum required version: %w", err)
 	}
-	if newVersion(minVersion).isGreaterThan(newVersion(spec.Version)) {
+	if versionIndex(version(minVersion)) < versionIndex(specVersion) {
 		return fmt.Errorf("the spec version must be at least v%v", minVersion)
 	}
 	return nil
@@ -82,64 +82,50 @@ func ValidateVersion(spec *Spec) error {
 
 // MinimumRequiredVersion determines the minimum spec version for the input spec.
 func MinimumRequiredVersion(spec *Spec) (string, error) {
-	minVersion := validSpecVersions.requiredVersion(spec)
-	return minVersion.String(), nil
+	minVersion := requiredVersion(spec)
+	return string(minVersion), nil
 }
 
-// version represents a semantic version string
+// version represents a CDI specification version.
 type version string
 
-// newVersion creates a version that can be used for semantic version comparisons.
+// newVersion normalizes a specification version by removing an optional leading v.
 func newVersion(v string) version {
-	return version("v" + strings.TrimPrefix(v, "v"))
-}
-
-// String returns the string representation of the version.
-// This trims a leading v if present.
-func (v version) String() string {
-	return strings.TrimPrefix(string(v), "v")
-}
-
-// isGreaterThan checks with a version is greater than the specified version.
-func (v version) isGreaterThan(o version) bool {
-	return semver.Compare(string(v), string(o)) > 0
-}
-
-// isLatest checks whether the version is the latest supported version
-func (v version) isLatest() bool {
-	return v == vCurrent
+	return version(strings.TrimPrefix(v, "v"))
 }
 
 type requiredFunc func(*Spec) bool
 
-type requiredVersionMap map[version]requiredFunc
-
 // isValidVersion checks whether the specified version is valid.
-// A version is valid if it is contained in the required version map.
-func (r requiredVersionMap) isValidVersion(specVersion string) bool {
-	_, ok := validSpecVersions[newVersion(specVersion)]
-
-	return ok
-}
-
-// requiredVersion returns the minimum version required for the given spec
-func (r requiredVersionMap) requiredVersion(spec *Spec) version {
-	minVersion := vEarliest
-
-	for v, isRequired := range validSpecVersions {
-		if isRequired == nil {
-			continue
-		}
-		if isRequired(spec) && v.isGreaterThan(minVersion) {
-			minVersion = v
-		}
-		// If we have already detected the latest version then no later version could be detected
-		if minVersion.isLatest() {
-			break
+// A version is valid if it is contained in the list of known spec versions.
+func isValidVersion(specVersion version) bool {
+	for _, known := range validSpecVersions {
+		if known.version == specVersion {
+			return true
 		}
 	}
+	return false
+}
 
-	return minVersion
+// requiredVersion returns the minimum version required for the given spec.
+func requiredVersion(spec *Spec) version {
+	for _, known := range validSpecVersions {
+		if known.isRequired != nil && known.isRequired(spec) {
+			return known.version
+		}
+	}
+	return vEarliest
+}
+
+// versionIndex returns the index of v in validSpecVersions, which is ordered
+// newest-to-oldest. It returns -1 for an unknown version.
+func versionIndex(v version) int {
+	for i, known := range validSpecVersions {
+		if known.version == v {
+			return i
+		}
+	}
+	return -1
 }
 
 // requiresV110 returns true if the spec uses v1.1.0 features.

--- a/specs-go/version_bench_test.go
+++ b/specs-go/version_bench_test.go
@@ -1,0 +1,24 @@
+package specs
+
+import "testing"
+
+func BenchmarkValidateVersion(b *testing.B) {
+	tests := []struct {
+		doc     string
+		version string
+	}{
+		{"first", "1.1.0"},
+		{"middle", "0.6.0"},
+		{"last", "0.1.0"},
+		{"invalid", "2.0.0"},
+	}
+
+	for _, tc := range tests {
+		b.Run(tc.doc, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_ = ValidateVersion(&Spec{Version: tc.version})
+			}
+		})
+	}
+}

--- a/specs-go/version_test.go
+++ b/specs-go/version_test.go
@@ -1,0 +1,252 @@
+/*
+   Copyright © The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package specs_test
+
+import (
+	"strings"
+	"testing"
+
+	"tags.cncf.io/container-device-interface/specs-go"
+)
+
+func TestMinimumRequiredVersion(t *testing.T) {
+	tests := []struct {
+		doc  string
+		spec *specs.Spec
+		want string
+	}{
+		{
+			doc:  "no version-specific features",
+			spec: &specs.Spec{},
+			want: "0.3.0",
+		},
+		{
+			doc: "v0.4.0 mount type",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					Mounts: []*specs.Mount{{Type: "bind"}},
+				},
+			},
+			want: "0.4.0",
+		},
+		{
+			doc: "v0.5.0 device node host path",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					DeviceNodes: []*specs.DeviceNode{{HostPath: "/dev/example"}},
+				},
+			},
+			want: "0.5.0",
+		},
+		{
+			doc: "v0.5.0 numeric device name",
+			spec: &specs.Spec{
+				Devices: []specs.Device{{Name: "0example"}},
+			},
+			want: "0.5.0",
+		},
+		{
+			doc: "v0.6.0 annotation",
+			spec: &specs.Spec{
+				Annotations: map[string]string{"example.com/key": "value"},
+			},
+			want: "0.6.0",
+		},
+		{
+			doc: "v0.6.0 dot in class",
+			spec: &specs.Spec{
+				Kind: "example.com/example.class",
+			},
+			want: "0.6.0",
+		},
+		{
+			doc: "v0.7.0 additional GIDs",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					AdditionalGIDs: []uint32{1},
+				},
+			},
+			want: "0.7.0",
+		},
+		{
+			doc: "v0.7.0 Intel RDT",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					IntelRdt: &specs.IntelRdt{},
+				},
+			},
+			want: "0.7.0",
+		},
+		{
+			doc: "v1.1.0 Intel RDT schemata",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					IntelRdt: &specs.IntelRdt{Schemata: []string{"L3:0=ff"}},
+				},
+			},
+			want: "1.1.0",
+		},
+		{
+			doc: "v1.1.0 Intel RDT monitoring",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					IntelRdt: &specs.IntelRdt{EnableMonitoring: true},
+				},
+			},
+			want: "1.1.0",
+		},
+		{
+			doc: "v1.1.0 network device",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					NetDevices: []*specs.LinuxNetDevice{{}},
+				},
+			},
+			want: "1.1.0",
+		},
+		{
+			doc: "device-scoped feature",
+			spec: &specs.Spec{
+				Devices: []specs.Device{{
+					ContainerEdits: specs.ContainerEdits{
+						AdditionalGIDs: []uint32{1},
+					},
+				}},
+			},
+			want: "0.7.0",
+		},
+		{
+			doc: "newest feature wins",
+			spec: &specs.Spec{
+				Annotations: map[string]string{"example.com/key": "value"},
+				ContainerEdits: specs.ContainerEdits{
+					AdditionalGIDs: []uint32{1},
+					NetDevices:     []*specs.LinuxNetDevice{{}},
+				},
+			},
+			want: "1.1.0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			got, err := specs.MinimumRequiredVersion(tc.spec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("MinimumRequiredVersion() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateVersion(t *testing.T) {
+	tests := []struct {
+		doc     string
+		version string
+		spec    *specs.Spec
+		wantErr string
+	}{
+		{
+			doc:     "current version",
+			version: "1.1.0",
+			spec:    &specs.Spec{},
+		},
+		{
+			doc:     "optional v prefix",
+			version: "v1.1.0",
+			spec:    &specs.Spec{},
+		},
+		{
+			doc:     "earliest supported version",
+			version: "0.3.0",
+			spec:    &specs.Spec{},
+		},
+		{
+			doc:     "known but unsupported v0.1.0",
+			version: "0.1.0",
+			spec:    &specs.Spec{},
+			wantErr: "the spec version must be at least v0.3.0",
+		},
+		{
+			doc:     "known but unsupported v0.2.0",
+			version: "v0.2.0",
+			spec:    &specs.Spec{},
+			wantErr: "the spec version must be at least v0.3.0",
+		},
+		{
+			doc:     "unknown version",
+			version: "1.2.0",
+			spec:    &specs.Spec{},
+			wantErr: `invalid version "1.2.0"`,
+		},
+		{
+			doc:     "malformed version",
+			version: "not-a-version",
+			spec:    &specs.Spec{},
+			wantErr: `invalid version "not-a-version"`,
+		},
+		{
+			doc:     "version too old for feature",
+			version: "0.6.0",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					AdditionalGIDs: []uint32{1},
+				},
+			},
+			wantErr: "the spec version must be at least v0.7.0",
+		},
+		{
+			doc:     "minimum version for feature",
+			version: "0.7.0",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					AdditionalGIDs: []uint32{1},
+				},
+			},
+		},
+		{
+			doc:     "newer version for feature",
+			version: "1.1.0",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					AdditionalGIDs: []uint32{1},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			tc.spec.Version = tc.version
+			err := specs.ValidateVersion(tc.spec)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateVersion() error = nil, want %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("ValidateVersion() error = %q, want error containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- [x] stacked on https://github.com/cncf-tags/container-device-interface/pull/332

----

### specs-go: remove x/mod semver dependency

CDI spec versions are a small, fixed set, so using
`golang.org/x/mod/semver` just to compare them is unnecessary.

Keep the versions in order instead and use that ordering for validation and
minimum-version checks. This also keeps support for versions with or without a
leading `v`.

As a side effect, `ValidateVersion` gets noticeably faster for valid versions
in local benchmarks, with no change in allocations.


I wrote a quick benchmark, but probably not worth to keep (so I can drop that commit);


```
pkg: tags.cncf.io/container-device-interface/specs-go
                          │ before.txt  │              after.txt              │
                          │   sec/op    │   sec/op     vs base                │
ValidateVersion/first-2     276.9n ± 1%   155.8n ± 1%  -43.71% (p=0.000 n=10)
ValidateVersion/middle-2    279.4n ± 1%   171.1n ± 1%  -38.77% (p=0.000 n=10)
ValidateVersion/last-2      354.9n ± 0%   259.9n ± 1%  -26.78% (p=0.000 n=10)
ValidateVersion/invalid-2   131.9n ± 1%   137.9n ± 1%   +4.55% (p=0.000 n=10)
geomean                     245.3n        175.8n       -28.33%

                          │ before.txt │              after.txt              │
                          │    B/op    │    B/op     vs base                 │
ValidateVersion/first-2     592.0 ± 0%   592.0 ± 0%       ~ (p=1.000 n=10) ¹
ValidateVersion/middle-2    592.0 ± 0%   592.0 ± 0%       ~ (p=1.000 n=10) ¹
ValidateVersion/last-2      672.0 ± 0%   672.0 ± 0%       ~ (p=1.000 n=10) ¹
ValidateVersion/invalid-2   280.0 ± 0%   280.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean                     506.7        506.7       +0.00%
¹ all samples are equal

                          │ before.txt │              after.txt              │
                          │ allocs/op  │ allocs/op   vs base                 │
ValidateVersion/first-2     5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=10) ¹
ValidateVersion/middle-2    5.000 ± 0%   5.000 ± 0%       ~ (p=1.000 n=10) ¹
ValidateVersion/last-2      8.000 ± 0%   8.000 ± 0%       ~ (p=1.000 n=10) ¹
ValidateVersion/invalid-2   4.000 ± 0%   4.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                     5.318        5.318       +0.00%
¹ all samples are equal
```
