### PR TITLE
internal/validation/k8s: remove unused validation helpers

### DIFF
--- a/internal/validation/k8s/validation.go
+++ b/internal/validation/k8s/validation.go
@@ -68,48 +68,7 @@ func IsQualifiedName(value string) []string {
 	return errs
 }
 
-const labelValueFmt string = "(" + qualifiedNameFmt + ")?"
-const labelValueErrMsg string = "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character"
-
-// LabelValueMaxLength is a label's max length
-const LabelValueMaxLength int = 63
-
-var labelValueRegexp = regexp.MustCompile("^" + labelValueFmt + "$")
-
-// IsValidLabelValue tests whether the value passed is a valid label value.  If
-// the value is not valid, a list of error strings is returned.  Otherwise an
-// empty list (or nil) is returned.
-func IsValidLabelValue(value string) []string {
-	var errs []string
-	if len(value) > LabelValueMaxLength {
-		errs = append(errs, MaxLenError(LabelValueMaxLength))
-	}
-	if !labelValueRegexp.MatchString(value) {
-		errs = append(errs, RegexError(labelValueErrMsg, labelValueFmt, "MyValue", "my_value", "12345"))
-	}
-	return errs
-}
-
 const dns1123LabelFmt string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
-const dns1123LabelErrMsg string = "a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"
-
-// DNS1123LabelMaxLength is a label's max length in DNS (RFC 1123)
-const DNS1123LabelMaxLength int = 63
-
-var dns1123LabelRegexp = regexp.MustCompile("^" + dns1123LabelFmt + "$")
-
-// IsDNS1123Label tests for a string that conforms to the definition of a label in
-// DNS (RFC 1123).
-func IsDNS1123Label(value string) []string {
-	var errs []string
-	if len(value) > DNS1123LabelMaxLength {
-		errs = append(errs, MaxLenError(DNS1123LabelMaxLength))
-	}
-	if !dns1123LabelRegexp.MatchString(value) {
-		errs = append(errs, RegexError(dns1123LabelErrMsg, dns1123LabelFmt, "my-name", "123-abc"))
-	}
-	return errs
-}
 
 const dns1123SubdomainFmt string = dns1123LabelFmt + "(\\." + dns1123LabelFmt + ")*"
 const dns1123SubdomainErrorMsg string = "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"
@@ -128,49 +87,6 @@ func IsDNS1123Subdomain(value string) []string {
 	}
 	if !dns1123SubdomainRegexp.MatchString(value) {
 		errs = append(errs, RegexError(dns1123SubdomainErrorMsg, dns1123SubdomainFmt, "example.com"))
-	}
-	return errs
-}
-
-const dns1035LabelFmt string = "[a-z]([-a-z0-9]*[a-z0-9])?"
-const dns1035LabelErrMsg string = "a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character"
-
-// DNS1035LabelMaxLength is a label's max length in DNS (RFC 1035)
-const DNS1035LabelMaxLength int = 63
-
-var dns1035LabelRegexp = regexp.MustCompile("^" + dns1035LabelFmt + "$")
-
-// IsDNS1035Label tests for a string that conforms to the definition of a label in
-// DNS (RFC 1035).
-func IsDNS1035Label(value string) []string {
-	var errs []string
-	if len(value) > DNS1035LabelMaxLength {
-		errs = append(errs, MaxLenError(DNS1035LabelMaxLength))
-	}
-	if !dns1035LabelRegexp.MatchString(value) {
-		errs = append(errs, RegexError(dns1035LabelErrMsg, dns1035LabelFmt, "my-name", "abc-123"))
-	}
-	return errs
-}
-
-// wildcard definition - RFC 1034 section 4.3.3.
-// examples:
-// - valid: *.bar.com, *.foo.bar.com
-// - invalid: *.*.bar.com, *.foo.*.com, *bar.com, f*.bar.com, *
-const wildcardDNS1123SubdomainFmt = "\\*\\." + dns1123SubdomainFmt
-const wildcardDNS1123SubdomainErrMsg = "a wildcard DNS-1123 subdomain must start with '*.', followed by a valid DNS subdomain, which must consist of lower case alphanumeric characters, '-' or '.' and end with an alphanumeric character"
-
-// IsWildcardDNS1123Subdomain tests for a string that conforms to the definition of a
-// wildcard subdomain in DNS (RFC 1034 section 4.3.3).
-func IsWildcardDNS1123Subdomain(value string) []string {
-	wildcardDNS1123SubdomainRegexp := regexp.MustCompile("^" + wildcardDNS1123SubdomainFmt + "$")
-
-	var errs []string
-	if len(value) > DNS1123SubdomainMaxLength {
-		errs = append(errs, MaxLenError(DNS1123SubdomainMaxLength))
-	}
-	if !wildcardDNS1123SubdomainRegexp.MatchString(value) {
-		errs = append(errs, RegexError(wildcardDNS1123SubdomainErrMsg, wildcardDNS1123SubdomainFmt, "*.example.com"))
 	}
 	return errs
 }
@@ -208,10 +124,4 @@ func prefixEach(msgs []string, prefix string) []string {
 		msgs[i] = prefix + msgs[i]
 	}
 	return msgs
-}
-
-// InclusiveRangeError returns a string explanation of a numeric "must be
-// between" validation failure.
-func InclusiveRangeError(lo, hi int) string {
-	return fmt.Sprintf(`must be between %d and %d, inclusive`, lo, hi)
 }


### PR DESCRIPTION
This package contained various helpers copied from the Kubernetes validation package that were unused. Some of these used package-level regular expressions (`regexp.MustCompile`), which are compiled during package initialization, causing some overhead if the package is imported.

Remove the unused code to reduce the overhead. Tested with a minimal binary importing the package (`import _ "tags.cncf.io/container-device-interface/internal/validation"`)

Running with `GODEBUG=inittrace=1` reduced initialization allocations from `27,848 bytes -> 13,400 bytes` (~52%) and `274 allocs -> 120 allocs` (~56%), and a slight reduction in live heap usage (`HeapAlloc: 232,696 -> 229,336`, `HeapInuse: 581,632 -> 540,672`).