### PR TITLE
replace strings.Split for strings.Cut

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -83,13 +83,12 @@ func ParseDevice(device string) (string, string, string) {
 		return "", "", device
 	}
 
-	parts := strings.SplitN(device, "=", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+	qualifier, name, ok := strings.Cut(device, "=")
+	if !ok || qualifier == "" || name == "" {
 		return "", "", device
 	}
 
-	name := parts[1]
-	vendor, class := ParseQualifier(parts[0])
+	vendor, class := ParseQualifier(qualifier)
 	if vendor == "" {
 		return "", "", device
 	}
@@ -105,11 +104,11 @@ func ParseDevice(device string) (string, string, string) {
 // If parsing fails, an empty vendor and the class set to the
 // verbatim input is returned.
 func ParseQualifier(kind string) (string, string) {
-	parts := strings.SplitN(kind, "/", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+	qualifier, value, ok := strings.Cut(kind, "/")
+	if !ok || qualifier == "" || value == "" {
 		return "", kind
 	}
-	return parts[0], parts[1]
+	return qualifier, value
 }
 
 // ValidateVendorName checks the validity of a vendor name.

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -209,23 +209,20 @@ func requiresV070(spec *Spec) bool {
 // requiresV060 returns true if the spec uses v0.6.0 features
 func requiresV060(spec *Spec) bool {
 	// The v0.6.0 spec allows annotations to be specified at a spec level
-	for range spec.Annotations {
+	if len(spec.Annotations) > 0 {
 		return true
 	}
 
 	// The v0.6.0 spec allows annotations to be specified at a device level
 	for _, d := range spec.Devices {
-		for range d.Annotations {
+		if len(d.Annotations) > 0 {
 			return true
 		}
 	}
 
 	// The v0.6.0 spec allows dots "." in Kind name label (class)
-	if !strings.Contains(spec.Kind, "/") {
-		return false
-	}
-	class := strings.SplitN(spec.Kind, "/", 2)[1]
-	return strings.Contains(class, ".")
+	_, class, ok := strings.Cut(spec.Kind, "/")
+	return ok && strings.Contains(class, ".")
 }
 
 // requiresV050 returns true if the spec uses v0.5.0 features


### PR DESCRIPTION
Use strings.Cut to simplify the code and to reduce allocations. Also simplify annotation checks for readability.