### PR TITLE
pkg/cdi: synchronize access to specDirs

### DIFF
--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -281,6 +281,8 @@ func (c *Cache) InjectDevices(ociSpec *oci.Spec, devices ...string) ([]string, e
 // highestPrioritySpecDir returns the Spec directory with highest priority
 // and its priority.
 func (c *Cache) highestPrioritySpecDir() (string, int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if len(c.specDirs) == 0 {
 		return "", -1
 	}

--- a/pkg/cdi/cache_test.go
+++ b/pkg/cdi/cache_test.go
@@ -1869,6 +1869,40 @@ func updateSpecDirs(dir string, etc, run map[string]string) error {
 	return updateTestDir(dir, updates)
 }
 
+// TestCacheConcurrentConfigure verifies concurrent spec directory access is synchronized.
+func TestCacheConcurrentConfigure(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	cache, err := NewCache(WithSpecDirs(dir1))
+	require.NoError(t, err)
+
+	const iterations = 1000
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if i%2 == 0 {
+				_ = cache.Configure(WithSpecDirs(dir1))
+			} else {
+				_ = cache.Configure(WithSpecDirs(dir1, dir2))
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			cache.highestPrioritySpecDir()
+		}
+	}()
+
+	wg.Wait()
+}
+
 func int64ptr(v int64) *int64 {
 	return &v
 }


### PR DESCRIPTION
Cache.Configure can replace specDirs while holding the cache lock, while highestPrioritySpecDir reads it without synchronization.

Because highestPrioritySpecDir reads specDirs multiple times, a concurrent reconfiguration can make those reads observe different slices, potentially resulting in a panic.


A small test was added to catch the race;

```
go test -race -run TestCacheConcurrentConfigure ./pkg/cdi
==================
WARNING: DATA RACE
Read at 0x00c0001386e8 by goroutine 11:
  tags.cncf.io/container-device-interface/pkg/cdi.(*Cache).highestPrioritySpecDir()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache.go:271 +0xa8
  tags.cncf.io/container-device-interface/pkg/cdi.TestCacheConcurrentConfigure.func2()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache_test.go:1898 +0xf8

Previous write at 0x00c0001386e8 by goroutine 10:
  tags.cncf.io/container-device-interface/pkg/cdi.WithSpecDirs.func1()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/spec-dirs.go:55 +0x108
  tags.cncf.io/container-device-interface/pkg/cdi.(*Cache).configure()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache.go:110 +0x58
  tags.cncf.io/container-device-interface/pkg/cdi.(*Cache).Configure()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache.go:101 +0x94
  tags.cncf.io/container-device-interface/pkg/cdi.TestCacheConcurrentConfigure.func1()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache_test.go:1888 +0x130

Goroutine 11 (running) created at:
  tags.cncf.io/container-device-interface/pkg/cdi.TestCacheConcurrentConfigure()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache_test.go:1895 +0x2c0
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2101 +0x34

Goroutine 10 (running) created at:
  tags.cncf.io/container-device-interface/pkg/cdi.TestCacheConcurrentConfigure()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache_test.go:1884 +0x228
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2101 +0x34
==================
==================
WARNING: DATA RACE
Read at 0x00c00011ca00 by goroutine 11:
  tags.cncf.io/container-device-interface/pkg/cdi.(*Cache).highestPrioritySpecDir()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache.go:276 +0xf0
  tags.cncf.io/container-device-interface/pkg/cdi.TestCacheConcurrentConfigure.func2()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache_test.go:1898 +0xf8

Previous write at 0x00c00011ca00 by goroutine 10:
  tags.cncf.io/container-device-interface/pkg/cdi.WithSpecDirs.func1()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/spec-dirs.go:53 +0xc4
  tags.cncf.io/container-device-interface/pkg/cdi.(*Cache).configure()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache.go:110 +0x58
  tags.cncf.io/container-device-interface/pkg/cdi.(*Cache).Configure()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache.go:101 +0x94
  tags.cncf.io/container-device-interface/pkg/cdi.TestCacheConcurrentConfigure.func1()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache_test.go:1888 +0x130

Goroutine 11 (running) created at:
  tags.cncf.io/container-device-interface/pkg/cdi.TestCacheConcurrentConfigure()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache_test.go:1895 +0x2c0
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2101 +0x34

Goroutine 10 (running) created at:
  tags.cncf.io/container-device-interface/pkg/cdi.TestCacheConcurrentConfigure()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache_test.go:1884 +0x228
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2101 +0x34
==================
==================
WARNING: DATA RACE
Write at 0x00c0001386e8 by goroutine 10:
  tags.cncf.io/container-device-interface/pkg/cdi.WithSpecDirs.func1()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/spec-dirs.go:55 +0x108
  tags.cncf.io/container-device-interface/pkg/cdi.(*Cache).configure()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache.go:110 +0x58
  tags.cncf.io/container-device-interface/pkg/cdi.(*Cache).Configure()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache.go:101 +0x94
  tags.cncf.io/container-device-interface/pkg/cdi.TestCacheConcurrentConfigure.func1()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache_test.go:1890 +0x1f0

Previous read at 0x00c0001386e8 by goroutine 11:
  tags.cncf.io/container-device-interface/pkg/cdi.(*Cache).highestPrioritySpecDir()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache.go:275 +0xbc
  tags.cncf.io/container-device-interface/pkg/cdi.TestCacheConcurrentConfigure.func2()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache_test.go:1898 +0xf8

Goroutine 10 (running) created at:
  tags.cncf.io/container-device-interface/pkg/cdi.TestCacheConcurrentConfigure()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache_test.go:1884 +0x228
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2101 +0x34

Goroutine 11 (finished) created at:
  tags.cncf.io/container-device-interface/pkg/cdi.TestCacheConcurrentConfigure()
      /Users/thajeztah/go/src/github.com/cncf-tags/container-device-interface/pkg/cdi/cache_test.go:1895 +0x2c0
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2036 +0x164
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.26.5/libexec/src/testing/testing.go:2101 +0x34
==================
--- FAIL: TestCacheConcurrentConfigure (0.17s)
    testing.go:1712: race detected during execution of test
FAIL
FAIL	tags.cncf.io/container-device-interface/pkg/cdi	0.506s
FAIL
```
