### PR TITLE
pkg/cdi: fix deprecations, add doc-links and "go fix"

### DIFF
--- a/pkg/cdi/container-edits.go
+++ b/pkg/cdi/container-edits.go
@@ -397,7 +397,9 @@ type IntelRdt struct {
 
 // ValidateIntelRdt validates the IntelRdt configuration.
 //
-// Deprecated: ValidateIntelRdt is deprecated use IntelRdt.Validate() instead.
+// Deprecated: use [*IntelRdt.Validate] instead.
+//
+//go:fix inline
 func ValidateIntelRdt(i *cdi.IntelRdt) error {
 	return (&IntelRdt{i}).Validate()
 }

--- a/pkg/cdi/spec.go
+++ b/pkg/cdi/spec.go
@@ -207,7 +207,10 @@ func (s *Spec) edits() *ContainerEdits {
 }
 
 // MinimumRequiredVersion determines the minimum spec version for the input spec.
-// Deprecated: use cdi.MinimumRequiredVersion instead
+//
+// Deprecated: use [cdi.MinimumRequiredVersion] instead.
+//
+//go:fix inline
 func MinimumRequiredVersion(spec *cdi.Spec) (string, error) {
 	return cdi.MinimumRequiredVersion(spec)
 }


### PR DESCRIPTION
- relates to https://github.com/cncf-tags/container-device-interface/pull/208
- relates to https://github.com/cncf-tags/container-device-interface/pull/214


The deprecation for `MinimumRequiredVersion` was incorrect.

This function was moved to specs-go in 1e39659e8626d0d19c49bbc07d40524eb95ee5e0, and deprecated in 6abc5e00d4c9167faccb7d9ad05c4db62ba75d8c, but the deprecation comment was missing a newline, which prevented some tools (and pkg.go.dev) from marking it deprecated.

While updating, also updated the deprecation for `ValidateIntelRdt`

This patch:

- Fixes the deprecation, adding the missing newline
- Updates the deprecation messages to use a doc-style link
- Adds `//go:fix inline` annotations to allow automatic migration with `go fix`

updates 6abc5e00d4c9167faccb7d9ad05c4db62ba75d8c
updates 1e39659e8626d0d19c49bbc07d40524eb95ee5e0
updates 1ebf29821b1338d19836a934e4b4f89582903df3

Before this patch:

<img width="973" height="170" alt="Screenshot 2026-08-09 at 13 34 17" src="https://github.com/user-attachments/assets/f4f32da4-7226-4c02-b524-82b00865c9b1" />
<img width="617" height="223" alt="Screenshot 2026-08-09 at 13 41 11" src="https://github.com/user-attachments/assets/b2ca91e3-3c0c-48e8-92b8-a1ebf0cd5d23" />

After this patch:

<img width="503" height="72" alt="Screenshot 2026-08-09 at 13 39 16" src="https://github.com/user-attachments/assets/5013b71c-d628-4f48-bb6a-67403bea7400" />
<img width="756" height="230" alt="Screenshot 2026-08-09 at 13 39 04" src="https://github.com/user-attachments/assets/2f72d811-0f28-4d52-b1db-5225037bf99f" />
<img width="534" height="232" alt="Screenshot 2026-08-09 at 13 41 42" src="https://github.com/user-attachments/assets/95a69669-da63-4084-892a-c02437688b9b" />


The `//go:fix` allows automatic migration, e.g.;

```go
package cdi

func foo() {
    ValidateIntelRdt(nil)
    MinimumRequiredVersion(nil)
}
```

After running `go fix -mod=readonly -all ./...`;

```go
package cdi

import cdi "tags.cncf.io/container-device-interface/specs-go"

func foo() {
	(&IntelRdt{nil}).Validate()
	cdi.MinimumRequiredVersion(nil)
}
```


