### PR TITLE
pkg/cdi: deprecate ErrStopScan and use os.ReadDir for scanning Spec directories

### DIFF
--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -172,7 +172,6 @@ func (c *Cache) refresh() error {
 	}
 
 	_ = scanSpecDirs(c.specDirs, func(path string, priority int, spec *Spec, err error) error {
-		path = filepath.Clean(path)
 		if err != nil {
 			collectError(fmt.Errorf("failed to load CDI Spec %w", err), path)
 			return nil

--- a/pkg/cdi/spec-dirs.go
+++ b/pkg/cdi/spec-dirs.go
@@ -31,10 +31,10 @@ const (
 )
 
 // DefaultSpecDirs is the default Spec directory configuration.
-// While altering this variable changes the package defaults,
-// the preferred way of overriding the default directories is
-// to use a WithSpecDirs options. Otherwise the change is only
-// effective if it takes place before creating the cache instance.
+//
+// The preferred way of overriding the default directories is
+// to use [WithSpecDirs], otherwise the change is only effective
+// if it takes place before creating the cache instance.
 var DefaultSpecDirs = []string{DefaultStaticDir, DefaultDynamicDir}
 
 // ErrStopScan can be returned from a scanSpecFunc to stop the scan.

--- a/pkg/cdi/spec-dirs.go
+++ b/pkg/cdi/spec-dirs.go
@@ -69,46 +69,33 @@ type scanSpecFunc func(string, int, *Spec, error) error
 //
 // Scanning stops once all files have been processed or when the scan
 // function returns an error. The result of ScanSpecDirs is the error
-// returned by the scan function, if any. ScanSpecDirs silently skips
-// any subdirectories.
+// returned by the scan function, if any. ScanSpecDirs does not recurse
+// into subdirectories.
 func scanSpecDirs(dirs []string, scanFn scanSpecFunc) error {
-	var (
-		spec *Spec
-		err  error
-	)
-
 	for priority, dir := range dirs {
-		err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-			// for initial stat failure Walk calls us with nil info
-			if info == nil {
-				if errors.Is(err, fs.ErrNotExist) {
-					return nil
-				}
-				return err
-			}
-			// first call from Walk is for dir itself, others we skip
-			if info.IsDir() {
-				if path == dir {
-					return nil
-				}
-				return filepath.SkipDir
+		entries, err := os.ReadDir(dir)
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
 			}
 
 			// ignore obviously non-Spec files
-			if ext := filepath.Ext(path); ext != ".json" && ext != ".yaml" {
-				return nil
+			if ext := filepath.Ext(entry.Name()); ext != ".json" && ext != ".yaml" {
+				continue
 			}
 
-			if err != nil {
-				return scanFn(path, priority, nil, err)
+			path := filepath.Join(dir, entry.Name())
+			spec, specErr := ReadSpec(path, priority) // ignore specErr; it's recorded through scanFn
+			if err := scanFn(path, priority, spec, specErr); err != nil {
+				return err
 			}
-
-			spec, err = ReadSpec(path, priority)
-			return scanFn(path, priority, spec, err)
-		})
-
-		if err != nil {
-			return err
 		}
 	}
 

--- a/pkg/cdi/spec-dirs.go
+++ b/pkg/cdi/spec-dirs.go
@@ -30,16 +30,17 @@ const (
 	DefaultDynamicDir = "/var/run/cdi"
 )
 
-var (
-	// DefaultSpecDirs is the default Spec directory configuration.
-	// While altering this variable changes the package defaults,
-	// the preferred way of overriding the default directories is
-	// to use a WithSpecDirs options. Otherwise the change is only
-	// effective if it takes place before creating the cache instance.
-	DefaultSpecDirs = []string{DefaultStaticDir, DefaultDynamicDir}
-	// ErrStopScan can be returned from a ScanSpecFunc to stop the scan.
-	ErrStopScan = errors.New("stop Spec scan")
-)
+// DefaultSpecDirs is the default Spec directory configuration.
+// While altering this variable changes the package defaults,
+// the preferred way of overriding the default directories is
+// to use a WithSpecDirs options. Otherwise the change is only
+// effective if it takes place before creating the cache instance.
+var DefaultSpecDirs = []string{DefaultStaticDir, DefaultDynamicDir}
+
+// ErrStopScan can be returned from a scanSpecFunc to stop the scan.
+//
+// Deprecated: ErrStopScan was only used by internal scan callbacks and is no longer used.
+var ErrStopScan = errors.New("stop Spec scan")
 
 // WithSpecDirs returns an option to override the CDI Spec directories.
 func WithSpecDirs(dirs ...string) Option {
@@ -68,9 +69,8 @@ type scanSpecFunc func(string, int, *Spec, error) error
 //
 // Scanning stops once all files have been processed or when the scan
 // function returns an error. The result of ScanSpecDirs is the error
-// returned by the scan function, if any. The special error ErrStopScan
-// can be used to terminate the scan gracefully without ScanSpecDirs
-// returning an error. ScanSpecDirs silently skips any subdirectories.
+// returned by the scan function, if any. ScanSpecDirs silently skips
+// any subdirectories.
 func scanSpecDirs(dirs []string, scanFn scanSpecFunc) error {
 	var (
 		spec *Spec
@@ -107,7 +107,7 @@ func scanSpecDirs(dirs []string, scanFn scanSpecFunc) error {
 			return scanFn(path, priority, spec, err)
 		})
 
-		if err != nil && err != ErrStopScan {
+		if err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
### pkg/cdi: deprecate ErrStopScan

`ErrStopScan` was introduced with the internal `scanSpecFunc` callback in
b730453b8e7e4550ebd7c7b7e836b5f8e64929c0, but never used, and external
callers have never been able to use it to control Spec scanning.

Deprecate it, and remove special handling from the scanner.

### pkg/cdi: touch-up godoc for DefaultSpecDirs

### pkg/cdi: use os.ReadDir for scanning Spec directories

Spec directory scanning is intentionally non-recursive, so use `os.ReadDir`
instead of `filepath.Walk` and process only the immediate directory entries.

This better matches the intended behavior, simplifies the scanning logic,
and avoids the `os.Lstat` call that `filepath.Walk` performs for every file
or directory.

### pkg/cdi: Cache.refresh: remove redundant filepath.Clean

The function is used as a callback for scanSpecDirs, which constructs
the paths passed to the callback with `filepath.Join`, and already cleaned.