### PR TITLE
pkg/cdi: fix cache refresh handling for filesystem events

### DIFF
--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -495,10 +495,11 @@ func (w *watch) watch(fsw *fsnotify.Watcher, c *Cache) {
 				return
 			}
 
-			if (event.Op & eventMask) == 0 {
+			fsOp := event.Op & eventMask
+			if fsOp == 0 {
 				continue
 			}
-			if event.Op == fsnotify.Write || event.Op == fsnotify.Create {
+			if fsOp&(fsnotify.Write|fsnotify.Create) != 0 {
 				if ext := filepath.Ext(event.Name); ext != ".json" && ext != ".yaml" {
 					continue
 				}
@@ -507,7 +508,7 @@ func (w *watch) watch(fsw *fsnotify.Watcher, c *Cache) {
 			c.mu.Lock()
 			_, isTracked := w.tracked[event.Name]
 
-			if event.Op == fsnotify.Remove && isTracked {
+			if fsOp&fsnotify.Remove != 0 && isTracked {
 				w.markRemoved(c.dirErrors, event.Name)
 			}
 			w.update(c.dirErrors)

--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -499,15 +499,15 @@ func (w *watch) watch(fsw *fsnotify.Watcher, c *Cache) {
 			if fsOp == 0 {
 				continue
 			}
-			if fsOp&(fsnotify.Write|fsnotify.Create) != 0 {
-				if ext := filepath.Ext(event.Name); ext != ".json" && ext != ".yaml" {
-					continue
-				}
-			}
 
 			c.mu.Lock()
 			_, isTracked := w.tracked[event.Name]
 
+			// Ignore changes unrelated to Spec files or configured Spec directories.
+			if ext := filepath.Ext(event.Name); ext != ".json" && ext != ".yaml" && !isTracked {
+				c.mu.Unlock()
+				continue
+			}
 			if fsOp&fsnotify.Remove != 0 && isTracked {
 				w.markRemoved(c.dirErrors, event.Name)
 			}

--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -507,11 +507,12 @@ func (w *watch) watch(fsw *fsnotify.Watcher, c *Cache) {
 			}
 
 			c.mu.Lock()
-			if event.Op == fsnotify.Remove && w.tracked[event.Name] {
-				w.update(c.dirErrors, event.Name)
-			} else {
-				w.update(c.dirErrors)
+			_, isTracked := w.tracked[event.Name]
+
+			if event.Op == fsnotify.Remove && isTracked {
+				w.markRemoved(c.dirErrors, event.Name)
 			}
+			w.update(c.dirErrors)
 			c.refresh()
 			c.mu.Unlock()
 
@@ -523,8 +524,16 @@ func (w *watch) watch(fsw *fsnotify.Watcher, c *Cache) {
 	}
 }
 
-// Update watch with pending/missing or removed directories.
-func (w *watch) update(dirErrors map[string]error, removed ...string) bool {
+// markRemoved marks a configured Spec directory as not currently watched so
+// its watch can be restored if the directory is recreated.
+func (w *watch) markRemoved(dirErrors map[string]error, dir string) {
+	w.tracked[dir] = false
+	dirErrors[dir] = errors.New("directory removed")
+}
+
+// update restores watches for configured directories that are not currently
+// being watched. It reports whether any watches were restored.
+func (w *watch) update(dirErrors map[string]error) bool {
 	// If we failed to create an fsnotify.Watcher we have a nil watcher here
 	// (but with autoRefresh left on). One known case when this can happen is
 	// if we have too many open files. In that case we always return true and
@@ -534,25 +543,18 @@ func (w *watch) update(dirErrors map[string]error, removed ...string) bool {
 	}
 
 	var update bool
-	for dir, ok := range w.tracked {
-		if ok {
+	for dir, watched := range w.tracked {
+		if watched {
 			continue
 		}
 
-		err := w.watcher.Add(dir)
-		if err == nil {
-			w.tracked[dir] = true
-			delete(dirErrors, dir)
-			update = true
-		} else {
-			w.tracked[dir] = false
+		if err := w.watcher.Add(dir); err != nil {
 			dirErrors[dir] = fmt.Errorf("failed to monitor for changes: %w", err)
+			continue
 		}
-	}
 
-	for _, dir := range removed {
-		w.tracked[dir] = false
-		dirErrors[dir] = errors.New("directory removed")
+		w.tracked[dir] = true
+		delete(dirErrors, dir)
 		update = true
 	}
 

--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -23,7 +23,6 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -484,11 +483,10 @@ func (w *watch) stop() {
 
 // Watch Spec directory changes, triggering a refresh if necessary.
 func (w *watch) watch(fsw *fsnotify.Watcher, c *Cache) {
-	eventMask := fsnotify.Rename | fsnotify.Remove | fsnotify.Write
-	// On macOS, we also need to watch for Create events.
-	if runtime.GOOS == "darwin" {
-		eventMask |= fsnotify.Create
-	}
+	// Watch for Spec file changes. Atomic writes may create a temporary file and
+	// rename it into place. On Linux, fsnotify reports the destination of such a
+	// rename as a Create event, so Create must be watched on all platforms.
+	eventMask := fsnotify.Create | fsnotify.Rename | fsnotify.Remove | fsnotify.Write
 
 	for {
 		select {


### PR DESCRIPTION
- [x] stacked on https://github.com/cncf-tags/container-device-interface/pull/345
- [x] https://github.com/cncf-tags/container-device-interface/pull/358
- fixes https://github.com/cncf-tags/container-device-interface/pull/358#discussion_r3869784905

### pkg/cdi: simplify restoration of removed directory watches

Handle removal of watched Spec directories separately from restoring
missing watches.

Previously update() accepted an optional removed directory and marked it
as unwatched only after attempting to restore other missing watches. This
required callers to distinguish between normal updates and directory
removal, and caused update() to serve two separate purposes.

Add markRemoved() to update the watch state when fsnotify reports that a
watched directory was removed, then call update() unconditionally to
restore any watches that are currently missing. This also allows a
directory that was removed and recreated concurrently to have its watch
restored immediately.

This keeps update() focused on reconciling missing watches and removes
the special-case removed-directory argument.


### pkg/cdi: watch for Create events on all platforms

Include fsnotify.Create in the event mask on all platforms instead of only
on macOS.

Spec files can be written atomically by creating a temporary file and
renaming it into place. On Linux, fsnotify reports the destination of such
a rename as a Create event. Without watching Create events, the cache may
miss the new Spec and only refresh because of an unrelated event for the
temporary file.

Watching Create events directly ensures that newly created or atomically
replaced Spec files trigger a cache refresh on all platforms.


### pkg/cdi: handle fsnotify operations as a bitmask

`fsnotify.Event.Op` is a bitmask and can contain multiple operations, but the
watcher compared it directly against individual operation values.

As a result, combined events could bypass operation-specific handling, such as
filtering writes and creates by file extension or detecting removal of a
watched directory.

Mask the operations we are interested in and test the individual bits instead.

### pkg/cdi: ignore unrelated filesystem events

The watcher filtered write and create events by file extension, but rename
and remove events for unrelated files would still trigger a refresh of the
CDI cache.

Apply the same Spec-file filtering to all relevant filesystem events, while
still processing events for configured Spec directories themselves.

This avoids unnecessary rescans when non-Spec files in watched directories are
renamed or removed, without interfering with handling of removed Spec
directories.
