### PR TITLE
ci: apply zizmor hardening fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
   schedule:
       interval: "daily"
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,6 +1,9 @@
 ---
 name: Codespell
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,14 +9,16 @@ on:
 
 permissions:
   contents: read
-  # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  # pull-requests: read
-  # Optional: allow write access to checks to allow the action to annotate code in the PR.
-  checks: write
 
 jobs:
   golangci:
     name: lint
+    permissions:
+      contents: read
+      # Optional: allow read access to pull request. Use with `only-new-issues` option.
+      # pull-requests: read
+      # Optional: allow write access to checks to allow the action to annotate code in the PR.
+      checks: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,6 +1,9 @@
 on: [push, pull_request]
 name: Sanity
 
+permissions:
+  contents: read
+
 env:
   GO_VERSION: '1.24.x'
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v11
+    - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
       with:
         stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. This issue will be closed in 30 days unless new comments are made or the stale label is removed. To skip these checks, apply the "lifecycle/frozen" label.'
         stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. This PR will be closed in 30 days unless new comments are made or the stale label is removed. To skip these checks, apply the "lifecycle/frozen" label.'


### PR DESCRIPTION
Before this patch;

    zizmor --fix=all --min-severity medium .
    ...
    20 findings (5 ignored, 10 suppressed): 0 informational, 0 low, 5 medium, 0 high

With this patch;

    zizmor --fix=all --min-severity medium .
     INFO zizmor: 🌈 zizmor v1.29.0
     INFO audit: zizmor: 🌈 completed ./.github/dependabot.yml
     INFO audit: zizmor: 🌈 completed ./.github/workflows/codespell.yml
     INFO audit: zizmor: 🌈 completed ./.github/workflows/golangci-lint.yml
     INFO audit: zizmor: 🌈 completed ./.github/workflows/sanity.yml
     INFO audit: zizmor: 🌈 completed ./.github/workflows/stale.yaml
    No findings to report. Good job! (5 ignored, 8 suppressed)
    No fixes available to apply.