### PR TITLE
ci: test against oldest supported, oldstable, and stable Go versions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.24.x'
+          go-version: stable
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -38,13 +38,21 @@ jobs:
         make mod-tidy && git diff --exit-code
 
   test:
-    name: "Run tests"
+    name: "Run tests / Go ${{ matrix.go-version || 'minimum' }}"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - "" # leave empty to use go-version-file (use go.mod)
+          - oldstable
+          - stable
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: ${{ matrix.go-version }}
+        go-version-file: go.mod # used when go-version is empty
     - name: Test
       run: make test
 


### PR DESCRIPTION
stacked on / needs;

- [x] https://github.com/cncf-tags/container-device-interface/pull/352
- [x] https://github.com/cncf-tags/container-device-interface/pull/353


Add a matrix to run tests against the oldest supported version (as specified in go.mod), as well as current and previous stable Go.

Use a custom name for the job so that the names are stable, which helps when configuring GitHub branch policies.