### PR TITLE
ci: update golangci-lint to v2.13, and fix linting

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,4 +26,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.9.0
+          version: v2.13

--- a/pkg/cdi/cache_test.go
+++ b/pkg/cdi/cache_test.go
@@ -758,11 +758,11 @@ devices:
 			}
 
 			fssyncer := func() {
-				var sync = time.NewTimer(2 * time.Second)
+				var fsync = time.NewTimer(2 * time.Second)
 
 				defer func() {
-					if !sync.Stop() {
-						<-sync.C
+					if !fsync.Stop() {
+						<-fsync.C
 					}
 					wg.Done()
 				}()
@@ -774,9 +774,9 @@ devices:
 					case <-stopCh:
 						go osSync()
 						return
-					case <-sync.C:
+					case <-fsync.C:
 						go osSync()
-						sync.Reset(2 * time.Second)
+						fsync.Reset(2 * time.Second)
 					}
 				}
 			}
@@ -996,18 +996,18 @@ devices:
         major: 10
         minor: 2
       hooks:
-      - hookName: prestart
-        path: "/usr/local/bin/prestart-vendor-hook"
-        args:
-        - "--verbose"
-        env:
-        - "HOOK_ENV1=PRESTART_VAL1"
       - hookName: createRuntime
         path: "/usr/local/bin/cr-vendor-hook"
         args:
-        - "--debug"
+        - "--verbose"
         env:
         - "HOOK_ENV1=CREATE_RUNTIME_VAL1"
+      - hookName: createContainer
+        path: "/usr/local/bin/cc-vendor-hook"
+        args:
+        - "--debug"
+        env:
+        - "HOOK_ENV1=CREATE_CONTAINER_VAL1"
   - name: "dev3"
     containerEdits:
       env:
@@ -1055,18 +1055,18 @@ devices:
 					},
 				},
 				Hooks: &oci.Hooks{
-					Prestart: []oci.Hook{
-						{
-							Path: "/usr/local/bin/prestart-vendor-hook",
-							Args: []string{"--verbose"},
-							Env:  []string{"HOOK_ENV1=PRESTART_VAL1"},
-						},
-					},
 					CreateRuntime: []oci.Hook{
 						{
 							Path: "/usr/local/bin/cr-vendor-hook",
-							Args: []string{"--debug"},
+							Args: []string{"--verbose"},
 							Env:  []string{"HOOK_ENV1=CREATE_RUNTIME_VAL1"},
+						},
+					},
+					CreateContainer: []oci.Hook{
+						{
+							Path: "/usr/local/bin/cc-vendor-hook",
+							Args: []string{"--debug"},
+							Env:  []string{"HOOK_ENV1=CREATE_CONTAINER_VAL1"},
 						},
 					},
 				},

--- a/pkg/cdi/container-edits_test.go
+++ b/pkg/cdi/container-edits_test.go
@@ -655,7 +655,7 @@ func TestApplyContainerEdits(t *testing.T) {
 			},
 			result: &oci.Spec{
 				Hooks: &oci.Hooks{
-					Prestart: []oci.Hook{
+					Prestart: []oci.Hook{ //nolint:staticcheck // ignore SA1019 - Prestart is deprecated, but must be tested.
 						{
 							Path: "/usr/local/bin/prestart-vendor-hook",
 							Args: []string{"--verbose"},

--- a/pkg/cdi/container-edits_test.go
+++ b/pkg/cdi/container-edits_test.go
@@ -481,8 +481,8 @@ func TestApplyContainerEdits(t *testing.T) {
 					{
 						Path:        "/dev/nil",
 						Type:        "c",
-						Major:       1,
-						Minor:       3,
+						Major:       nullDeviceMajor,
+						Minor:       nullDeviceMinor,
 						Permissions: NoPermissions,
 					},
 				},
@@ -519,8 +519,8 @@ func TestApplyContainerEdits(t *testing.T) {
 					{
 						Path:        "/dev/nil",
 						Type:        "c",
-						Major:       1,
-						Minor:       3,
+						Major:       nullDeviceMajor,
+						Minor:       nullDeviceMinor,
 						Permissions: "",
 					},
 				},


### PR DESCRIPTION
- fixes https://github.com/cncf-tags/container-device-interface/issues/343

### pkg/cdi: fix tests when ran on macOS

### pkg/cdi: fix linting

Prestart hook is deprecated, so replace it for tests where suitable,
but keep a test to verify it's applied. Also rename a variable that
shadowed.


### ci: update golangci-lint to v2.13
