### PR TITLE
specs-go: fix benchmark compatibility with go1.19

### DIFF
--- a/specs-go/version_bench_test.go
+++ b/specs-go/version_bench_test.go
@@ -16,7 +16,7 @@ func BenchmarkValidateVersion(b *testing.B) {
 	for _, tc := range tests {
 		b.Run(tc.doc, func(b *testing.B) {
 			b.ReportAllocs()
-			for b.Loop() {
+			for i := 0; i < b.N; i++ {
 				_ = ValidateVersion(&Spec{Version: tc.version})
 			}
 		})


### PR DESCRIPTION
The go.mod defines go1.19, which does not yet support b.Loop;

    # tags.cncf.io/container-device-interface/specs-go [tags.cncf.io/container-device-interface/specs-go.test]
    Error: ./version_bench_test.go:19:10: b.Loop undefined (type *testing.B has no field or method Loop)
    FAIL	tags.cncf.io/container-device-interface/specs-go [build failed]