### PR TITLE
pkg/cdi: fix flaky TestRefreshCache

### DIFF
--- a/pkg/cdi/cache_test.go
+++ b/pkg/cdi/cache_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	oci "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 	cdi "tags.cncf.io/container-device-interface/specs-go"
@@ -562,7 +563,10 @@ devices:
 							return
 						}
 						if selfRefresh {
-							time.Sleep(100 * time.Millisecond)
+							require.EventuallyWithT(t, func(t *assert.CollectT) {
+								assert.Equal(t, tc.devices[idx], cache.ListDevices())
+								assert.Len(t, cache.GetErrors(), len(tc.errors[idx]))
+							}, time.Second, 10*time.Millisecond)
 						} else {
 							err = cache.Refresh()
 


### PR DESCRIPTION
Automatic cache refresh is performed asynchronously in response to filesystem events. Poll for the expected cache state instead of assuming that the refresh has completed after a fixed 100 ms delay.