### PR TITLE
pkg/cdi: clean up watcher lifecycle handling and simplify refresh logic

### DIFF
--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -132,7 +132,7 @@ func (c *Cache) configure(options ...Option) {
 		c.dirErrors = make(map[string]error)
 		c.watch.start(c.specDirs, &c.mu, c.refresh, c.dirErrors)
 	}
-	_ = c.refresh() // we record but ignore errors
+	c.refresh()
 }
 
 // Refresh rescans the CDI Spec directories and refreshes the Cache.
@@ -143,12 +143,14 @@ func (c *Cache) Refresh() error {
 	defer c.mu.Unlock()
 
 	// force a refresh in manual mode
-	if refreshed, err := c.refreshIfRequired(!c.autoRefresh); refreshed {
-		return err
+	if !c.autoRefresh {
+		c.refresh()
+	} else {
+		c.refreshIfRequired()
 	}
 
-	// collect and return cached errors, much like refresh() does it
-	errs := []error{}
+	// collect and return cached errors.
+	var errs []error
 	for _, specErrs := range c.errors {
 		errs = append(errs, errors.Join(specErrs...))
 	}
@@ -156,7 +158,7 @@ func (c *Cache) Refresh() error {
 }
 
 // Refresh the Cache by rescanning CDI Spec directories and files.
-func (c *Cache) refresh() error {
+func (c *Cache) refresh() {
 	var (
 		specs      = map[string][]*Spec{}
 		devices    = map[string]*Device{}
@@ -216,23 +218,14 @@ func (c *Cache) refresh() error {
 	c.specs = specs
 	c.devices = devices
 	c.errors = specErrors
-
-	errs := []error{}
-	for _, specErrs := range specErrors {
-		errs = append(errs, errors.Join(specErrs...))
-	}
-	return errors.Join(errs...)
 }
 
-// RefreshIfRequired triggers a refresh if necessary.
-func (c *Cache) refreshIfRequired(force bool) (bool, error) {
-	// We need to refresh if
-	// - it's forced by an explicit call to Refresh() in manual mode
-	// - a missing Spec dir appears (added to watch) in auto-refresh mode
-	if force || (c.autoRefresh && c.watch.update(c.dirErrors)) {
-		return true, c.refresh()
+// refreshIfRequired triggers a refresh if necessary.
+func (c *Cache) refreshIfRequired() {
+	// We need to refresh if a missing Spec dir appears (added to watch) in auto-refresh mode.
+	if c.autoRefresh && c.watch.update(c.dirErrors) {
+		c.refresh()
 	}
-	return false, nil
 }
 
 // InjectDevices injects the given qualified devices to an OCI Spec. It
@@ -245,7 +238,7 @@ func (c *Cache) InjectDevices(ociSpec *oci.Spec, devices ...string) ([]string, e
 	}
 
 	c.mu.Lock()
-	_, _ = c.refreshIfRequired(false) // we record but ignore errors
+	c.refreshIfRequired()
 	cachedDevices := c.devices
 	c.mu.Unlock()
 
@@ -359,7 +352,7 @@ func (c *Cache) GetDevice(device string) *Device {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	_, _ = c.refreshIfRequired(false) // we record but ignore errors
+	c.refreshIfRequired()
 
 	return c.devices[device]
 }
@@ -372,7 +365,7 @@ func (c *Cache) ListDevices() []string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	_, _ = c.refreshIfRequired(false) // we record but ignore errors
+	c.refreshIfRequired()
 
 	for name := range c.devices {
 		devices = append(devices, name)
@@ -390,7 +383,7 @@ func (c *Cache) ListVendors() []string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	_, _ = c.refreshIfRequired(false) // we record but ignore errors
+	c.refreshIfRequired()
 
 	for vendor := range c.specs {
 		vendors = append(vendors, vendor)
@@ -411,7 +404,7 @@ func (c *Cache) ListClasses() []string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	_, _ = c.refreshIfRequired(false) // we record but ignore errors
+	c.refreshIfRequired()
 
 	for _, specs := range c.specs {
 		for _, spec := range specs {
@@ -432,7 +425,7 @@ func (c *Cache) GetVendorSpecs(vendor string) []*Spec {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	_, _ = c.refreshIfRequired(false) // we record but ignore errors
+	c.refreshIfRequired()
 
 	return c.specs[vendor]
 }
@@ -499,7 +492,7 @@ type watch struct {
 }
 
 // Start watching the configured Spec directories.
-func (w *watch) start(dirs []string, m sync.Locker, refresh func() error, dirErrors map[string]error) {
+func (w *watch) start(dirs []string, m sync.Locker, refresh func(), dirErrors map[string]error) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		for _, dir := range dirs {
@@ -534,7 +527,7 @@ func (w *watch) stop() {
 }
 
 // Watch Spec directory changes, triggering a refresh if necessary.
-func (w *watch) watch(fsw *fsnotify.Watcher, m sync.Locker, refresh func() error, dirErrors map[string]error) {
+func (w *watch) watch(fsw *fsnotify.Watcher, m sync.Locker, refresh func(), dirErrors map[string]error) {
 	eventMask := fsnotify.Rename | fsnotify.Remove | fsnotify.Write
 	// On macOS, we also need to watch for Create events.
 	if runtime.GOOS == "darwin" {
@@ -563,7 +556,7 @@ func (w *watch) watch(fsw *fsnotify.Watcher, m sync.Locker, refresh func() error
 			} else {
 				w.update(dirErrors)
 			}
-			_ = refresh()
+			refresh()
 			m.Unlock()
 
 		case _, ok := <-fsw.Errors:

--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -129,8 +129,7 @@ func (c *Cache) configure(options ...Option) {
 	}
 
 	if c.autoRefresh {
-		c.dirErrors = make(map[string]error)
-		c.watch.start(c.specDirs, &c.mu, c.refresh, c.dirErrors)
+		c.watch.start(c)
 	}
 	c.refresh()
 }
@@ -491,28 +490,30 @@ type watch struct {
 	tracked map[string]bool
 }
 
-// Start watching the configured Spec directories.
-func (w *watch) start(dirs []string, m sync.Locker, refresh func(), dirErrors map[string]error) {
+// Start watching the Spec directories configured in the cache, recording
+// watch errors and triggering cache refreshes as directories change.
+func (w *watch) start(c *Cache) {
+	c.dirErrors = make(map[string]error)
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		for _, dir := range dirs {
-			dirErrors[dir] = fmt.Errorf("failed to create watcher: %w", err)
+		for _, dir := range c.specDirs {
+			c.dirErrors[dir] = fmt.Errorf("failed to create watcher: %w", err)
 		}
 		return
 	}
 
 	w.watcher = watcher
-	w.tracked = make(map[string]bool, len(dirs))
-	for _, dir := range dirs {
+	w.tracked = make(map[string]bool, len(c.specDirs))
+	for _, dir := range c.specDirs {
 		if err := watcher.Add(dir); err != nil {
-			dirErrors[dir] = fmt.Errorf("failed to monitor for changes: %w", err)
+			c.dirErrors[dir] = fmt.Errorf("failed to monitor for changes: %w", err)
 			w.tracked[dir] = false
 			continue
 		}
 		w.tracked[dir] = true
 	}
 
-	go w.watch(watcher, m, refresh, dirErrors)
+	go w.watch(watcher, c)
 }
 
 // Stop watching directories.
@@ -527,7 +528,7 @@ func (w *watch) stop() {
 }
 
 // Watch Spec directory changes, triggering a refresh if necessary.
-func (w *watch) watch(fsw *fsnotify.Watcher, m sync.Locker, refresh func(), dirErrors map[string]error) {
+func (w *watch) watch(fsw *fsnotify.Watcher, c *Cache) {
 	eventMask := fsnotify.Rename | fsnotify.Remove | fsnotify.Write
 	// On macOS, we also need to watch for Create events.
 	if runtime.GOOS == "darwin" {
@@ -550,14 +551,14 @@ func (w *watch) watch(fsw *fsnotify.Watcher, m sync.Locker, refresh func(), dirE
 				}
 			}
 
-			m.Lock()
+			c.mu.Lock()
 			if event.Op == fsnotify.Remove && w.tracked[event.Name] {
-				w.update(dirErrors, event.Name)
+				w.update(c.dirErrors, event.Name)
 			} else {
-				w.update(dirErrors)
+				w.update(c.dirErrors)
 			}
-			refresh()
-			m.Unlock()
+			c.refresh()
+			c.mu.Unlock()
 
 		case _, ok := <-fsw.Errors:
 			if !ok {

--- a/pkg/cdi/cache.go
+++ b/pkg/cdi/cache.go
@@ -121,16 +121,16 @@ func (c *Cache) Configure(options ...Option) error {
 // Configure the Cache. Start/stop CDI Spec directory watch, refresh
 // the Cache if necessary.
 func (c *Cache) configure(options ...Option) {
+	c.watch.stop()
+	c.dirErrors = nil
+
 	for _, o := range options {
 		o(c)
 	}
 
-	c.dirErrors = make(map[string]error)
-
-	c.watch.stop()
 	if c.autoRefresh {
-		c.watch.setup(c.specDirs, c.dirErrors)
-		c.watch.start(&c.mu, c.refresh, c.dirErrors)
+		c.dirErrors = make(map[string]error)
+		c.watch.start(c.specDirs, &c.mu, c.refresh, c.dirErrors)
 	}
 	_ = c.refresh() // we record but ignore errors
 }
@@ -498,18 +498,9 @@ type watch struct {
 	tracked map[string]bool
 }
 
-// Setup monitoring for the given Spec directories.
-func (w *watch) setup(dirs []string, dirErrors map[string]error) {
-	var (
-		dir string
-		err error
-	)
-	w.tracked = make(map[string]bool)
-	for _, dir = range dirs {
-		w.tracked[dir] = false
-	}
-
-	w.watcher, err = fsnotify.NewWatcher()
+// Start watching the configured Spec directories.
+func (w *watch) start(dirs []string, m sync.Locker, refresh func() error, dirErrors map[string]error) {
+	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		for _, dir := range dirs {
 			dirErrors[dir] = fmt.Errorf("failed to create watcher: %w", err)
@@ -517,12 +508,18 @@ func (w *watch) setup(dirs []string, dirErrors map[string]error) {
 		return
 	}
 
-	w.update(dirErrors)
-}
+	w.watcher = watcher
+	w.tracked = make(map[string]bool, len(dirs))
+	for _, dir := range dirs {
+		if err := watcher.Add(dir); err != nil {
+			dirErrors[dir] = fmt.Errorf("failed to monitor for changes: %w", err)
+			w.tracked[dir] = false
+			continue
+		}
+		w.tracked[dir] = true
+	}
 
-// Start watching Spec directories for relevant changes.
-func (w *watch) start(m sync.Locker, refresh func() error, dirErrors map[string]error) {
-	go w.watch(w.watcher, m, refresh, dirErrors)
+	go w.watch(watcher, m, refresh, dirErrors)
 }
 
 // Stop watching directories.
@@ -532,16 +529,12 @@ func (w *watch) stop() {
 	}
 
 	_ = w.watcher.Close()
+	w.watcher = nil
 	w.tracked = nil
 }
 
 // Watch Spec directory changes, triggering a refresh if necessary.
 func (w *watch) watch(fsw *fsnotify.Watcher, m sync.Locker, refresh func() error, dirErrors map[string]error) {
-	watch := fsw
-	if watch == nil {
-		return
-	}
-
 	eventMask := fsnotify.Rename | fsnotify.Remove | fsnotify.Write
 	// On macOS, we also need to watch for Create events.
 	if runtime.GOOS == "darwin" {
@@ -550,7 +543,7 @@ func (w *watch) watch(fsw *fsnotify.Watcher, m sync.Locker, refresh func() error
 
 	for {
 		select {
-		case event, ok := <-watch.Events:
+		case event, ok := <-fsw.Events:
 			if !ok {
 				return
 			}
@@ -573,7 +566,7 @@ func (w *watch) watch(fsw *fsnotify.Watcher, m sync.Locker, refresh func() error
 			_ = refresh()
 			m.Unlock()
 
-		case _, ok := <-watch.Errors:
+		case _, ok := <-fsw.Errors:
 			if !ok {
 				return
 			}


### PR DESCRIPTION
- part of https://github.com/cncf-tags/container-device-interface/pull/344

### pkg/cdi: clean up watcher lifecycle handling

- Stop the existing watcher before applying new cache options and resetting
  watcher-related errors, so the old watcher cannot observe partially updated
  configuration.
- Clear the watcher after closing so that we don't leave behind a stale,
  closed watcher.
- Combine watcher setup and startup so creating the fsnotify watcher,
  installing the initial directory watches, and starting the event loop happen
  as a single operation.
- Install the initial watches explicitly instead of routing startup through
  `watch.update`, and only initialize `watch.tracked` after successfully
  creating the watcher.
- Avoid starting the watch goroutine if creating the watcher failed.
- Remove the now-redundant nil check from `watch.watch` and use its `fsw`
  argument directly.


### pkg/cdi: simplify refresh logic

All callers of refreshIfRequired, except `Refresh`, only use it to perform
an automatic refresh when necessary and ignore refresh errors. `Refresh`,
on the other hand, needs to force a refresh in manual mode and return the
cached errors regardless of whether a refresh took place.

Move the logic to decide between "automatic" or "forced" refresh to the
`Refresh` method, and move collecting the cached / refreshed errors to
that method. The responsibility of `Cache.refresh` is now reduced to
refreshing the data and errors, and it's up to callers to collect errors
when needed.

### pkg/cdi: pass cache to watch helper

Pass the Cache directly to the watch helper instead of passing its
individual fields and methods separately, and initialize the directory
error state as part of starting the watch.

This keeps the watch setup and its cache state together.
