### PR TITLE
Bump version to v1.1.1

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -34,6 +34,7 @@ Released versions of the spec are available as Git tags.
 | v0.8.0 |   | Remove .ToOCI() functions from specs-go package. |
 | v1.0.0 |   | Move minimum version logic to specs-go package. |
 | v1.1.0 |   | Add `NetDevices` to `ContainerEdits`, `Schemata` and `EnableMonitoring` to `IntelRdt`. Dropped `EnableCMT` and `EnableMBM` fields from `IntelRdt`. |
+| v1.1.1 |   | No Spec changes. Remove semver dependency from specs-go and improve performance. |
 
 *Note*: spec loading fails on unknown fields and when the minimum required version is higher than the version specified in the spec. The minimum required version is determined based on the usage of fields mentioned in the table above. For example the minimum required version is v0.6.0 if the `Annotations` field is used in the spec, but `IntelRdt` is not.
 `MinimumRequiredVersion` API can be used to get the minimum required version.

--- a/cmd/cdi/go.mod
+++ b/cmd/cdi/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/spf13/cobra v1.6.0
 	github.com/stretchr/testify v1.12.1
 	go.yaml.in/yaml/v3 v3.0.5
-	tags.cncf.io/container-device-interface v1.1.0
+	tags.cncf.io/container-device-interface v1.1.1
 	tags.cncf.io/container-device-interface/schema v0.0.0
-	tags.cncf.io/container-device-interface/specs-go v1.1.0
+	tags.cncf.io/container-device-interface/specs-go v1.1.1
 )
 
 require (

--- a/cmd/validate/go.mod
+++ b/cmd/validate/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	tags.cncf.io/container-device-interface v1.1.0 // indirect
-	tags.cncf.io/container-device-interface/specs-go v1.1.0 // indirect
+	tags.cncf.io/container-device-interface v1.1.1 // indirect
+	tags.cncf.io/container-device-interface/specs-go v1.1.1 // indirect
 )
 
 replace (

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/stretchr/testify v1.12.1
 	go.yaml.in/yaml/v3 v3.0.5
 	golang.org/x/sys v0.19.0
-	tags.cncf.io/container-device-interface/specs-go v1.1.0
+	tags.cncf.io/container-device-interface/specs-go v1.1.1
 )
 
 replace tags.cncf.io/container-device-interface/specs-go => ./specs-go

--- a/schema/go.mod
+++ b/schema/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	github.com/stretchr/testify v1.12.1
 	go.yaml.in/yaml/v3 v3.0.5
-	tags.cncf.io/container-device-interface v1.1.0
-	tags.cncf.io/container-device-interface/specs-go v1.1.0
+	tags.cncf.io/container-device-interface v1.1.1
+	tags.cncf.io/container-device-interface/specs-go v1.1.1
 )
 
 require (


### PR DESCRIPTION
This includes a Spec module bump to v1.1.1.

Note that since there are no spec changes, we keep v1.1.0 as the current Spec version. The go module version is bumped to (and will be tagged as) `v1.1.1` though.
 
Related to #360 