### PR TITLE
Support wildcard device paths

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = .git,*.pdf,*.svg,*.sum,*.mod
-ignore-words-list = clos
+ignore-words-list = clos,renderd

--- a/SPEC.md
+++ b/SPEC.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-This is CDI **spec** version **1.1.0**.
+This is CDI **spec** version **1.2.0**.
 
 ### Update policy
 
@@ -35,6 +35,7 @@ Released versions of the spec are available as Git tags.
 | v1.0.0 |   | Move minimum version logic to specs-go package. |
 | v1.1.0 |   | Add `NetDevices` to `ContainerEdits`, `Schemata` and `EnableMonitoring` to `IntelRdt`. Dropped `EnableCMT` and `EnableMBM` fields from `IntelRdt`. |
 | v1.1.1 |   | No Spec changes. Remove semver dependency from specs-go and improve performance. |
+| v1.2.0 |   | Allow wildcards in the `Path` and `HostPath` of `DeviceNodes`. |
 
 *Note*: spec loading fails on unknown fields and when the minimum required version is higher than the version specified in the spec. The minimum required version is determined based on the usage of fields mentioned in the table above. For example the minimum required version is v0.6.0 if the `Annotations` field is used in the spec, but `IntelRdt` is not.
 `MinimumRequiredVersion` API can be used to get the minimum required version.
@@ -129,6 +130,7 @@ The keywords "must", "must not", "required", "shall", "shall not", "should", "sh
             ]
             "deviceNodes": [ (optional)
                 {
+                    // The last element of the path may be a wildcard pattern which gets expanded into the matching host device nodes.
                     "path": "<path>",
                     "hostPath": "<hostPath>" (optional),
                     "type": "<type>" (optional),
@@ -230,8 +232,8 @@ The `containerEdits` field is referenced in two places in the specification:
 The `containerEdits` field has the following definition:
   * `env` (array of strings in the format of "VARNAME=VARVALUE", OPTIONAL) describes the environment variables that should be set. These values are appended to the container environment array.
   * `deviceNodes` (array of objects, OPTIONAL) describes the device nodes that should be mounted:
-    * `path` (string, REQUIRED) path of the device within the container.
-    * `hostPath` (string, OPTIONAL) path of the device node on the host. If not specified the value for `path` is used. Added in v0.5.0.
+    * `path` (string, REQUIRED) path of the device within the container. May be a wildcard pattern, see [Wildcard device nodes](#wildcard-device-nodes). Wildcards added in v1.2.0.
+    * `hostPath` (string, OPTIONAL) path of the device node on the host. If not specified the value for `path` is used. May be a wildcard pattern, see [Wildcard device nodes](#wildcard-device-nodes). Added in v0.5.0, wildcards added in v1.2.0.
     * `type` (string, OPTIONAL) Device type: block, char, etc.
     * `major` (int64, OPTIONAL) Device major number.
     * `minor` (int64, OPTIONAL) Device minor number.
@@ -261,6 +263,42 @@ The `containerEdits` field has the following definition:
     * `schemata` (array of strings, OPTIONAL) RDT schema for the CLOS.
     * `enableMonitoring` (boolean, OPTIONAL) whether to enable memory bandwidth monitoring for the CLOS.
   * `additionalGids` (array of uint32s, OPTIONAL) A list of additional group IDs to add with the container process. These values are added to the `user.additionalGids` field in the OCI runtime specification. Values of 0 are ignored. Added in v0.7.0.
+
+#### Wildcard device nodes
+
+Added in v1.2.0. The `path` and `hostPath` of a device node may be a wildcard
+pattern, matching multiple device nodes on the host. This allows a device to
+cover all instances of a class of device nodes without the vendor having to
+enumerate them:
+
+```yaml
+cdiVersion: "1.2.0"
+kind: "vendor.com/device"
+devices:
+  - name: "all"
+    containerEdits:
+      deviceNodes:
+        - path: "/dev/dri/card*"
+        - path: "/dev/dri/renderD*"
+        - path: "/dev/mei*"
+          permissions: "rw"
+```
+
+The pattern syntax is that of Go's [path.Match](https://pkg.go.dev/path#Match).
+The following rules are applied:
+
+* A pattern MUST be an absolute path with no `.` or `..` elements.
+* Wildcards MUST only appear in the last element of the path, i.e. the directory
+  of the device nodes is always fixed.
+* A pattern is expanded when the container edits are applied to an OCI
+  specification, i.e. against the state of the host at container creation time.
+* A pattern is expanded to the matching host device nodes only, any other files
+  (regular files, directories etc) are silently ignored.
+* A pattern matching no host device nodes expands to an empty set.
+* `type`, `major` and `minor` MUST NOT be specified for a wildcard device
+  node, these are inherited from the host device node.
+* If `hostPath` is specified, the last elements of `path` and `hostPath` MUST be
+  an identical pattern.
 
 ## Error Handling
   * Kind requested is not present in any CDI file.

--- a/pkg/cdi/container-edits.go
+++ b/pkg/cdi/container-edits.go
@@ -88,7 +88,12 @@ func (e *ContainerEdits) Apply(spec *oci.Spec) error {
 		editor.AddMultipleProcessEnv(e.Env)
 	}
 
-	for _, d := range e.DeviceNodes {
+	deviceNodes, err := expandWildcards(e.DeviceNodes)
+	if err != nil {
+		return err
+	}
+
+	for _, d := range deviceNodes {
 		dn := DeviceNode{d}
 
 		err := dn.fillMissingInfo()
@@ -349,6 +354,9 @@ func (d *DeviceNode) Validate() error {
 	case strings.Trim(d.Permissions, "rwm") != "":
 		return fmt.Errorf("device %q: invalid permissions %q",
 			d.Path, d.Permissions)
+	}
+	if err := d.validateWildcards(); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/cdi/container-edits_unix.go
+++ b/pkg/cdi/container-edits_unix.go
@@ -22,8 +22,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"golang.org/x/sys/unix"
+	cdi "tags.cncf.io/container-device-interface/specs-go"
 )
 
 const (
@@ -74,6 +76,120 @@ func deviceInfoFromPath(path string) (*deviceInfo, error) {
 	}
 
 	return &di, nil
+}
+
+// validateWildcards validates the wildcard patterns (if any) of a device node.
+func (d *DeviceNode) validateWildcards() error {
+	pathIsPattern, hostPathIsPattern := cdi.HasWildcards(d.Path), cdi.HasWildcards(d.HostPath)
+	if !pathIsPattern && !hostPathIsPattern {
+		return nil
+	}
+
+	for _, p := range []string{d.Path, d.HostPath} {
+		if !cdi.HasWildcards(p) {
+			continue
+		}
+		// Require absolute path, and a "clean" path (rule out paths like "/dev/../etc/*")
+		if !filepath.IsAbs(p) || filepath.Clean(p) != p {
+			return fmt.Errorf("device %q: wildcard pattern %q is not an absolute, cleaned path", d.Path, p)
+		}
+		if _, err := filepath.Match(p, ""); err != nil {
+			return fmt.Errorf("device %q: invalid wildcard pattern %q: %w", d.Path, p, err)
+		}
+		if cdi.HasWildcards(filepath.Dir(p)) {
+			return fmt.Errorf("device %q: wildcards are only allowed in the last element of the path %q",
+				d.Path, p)
+		}
+	}
+
+	// The host device node determines the type and the device numbers, thus these must not be set
+	switch {
+	case d.Type != "":
+		return fmt.Errorf("device %q: type must not be set for a wildcard pattern", d.Path)
+	case d.Major != 0 || d.Minor != 0:
+		return fmt.Errorf("device %q: major/minor must not be set for a wildcard pattern", d.Path)
+	}
+
+	if d.HostPath == "" {
+		return nil
+	}
+
+	// The patterns of path and host path must be identical so that the container
+	// path of every match is unambiguous.
+	if filepath.Base(d.Path) != filepath.Base(d.HostPath) {
+		return fmt.Errorf("device %q: last element of path and hostPath %q must be an identical pattern",
+			d.Path, d.HostPath)
+	}
+
+	return nil
+}
+
+// expandWildcards expands device nodes that have paths with wildcard patterns into
+// actual device nodes to be injected into the container. Matches which are not
+// device nodes, e.g. regular files, directories and symlinks, are ignored. A
+// pattern matching no host device nodes expands to an empty list.
+func expandWildcards(nodes []*cdi.DeviceNode) ([]*cdi.DeviceNode, error) {
+	expanded := make([]*cdi.DeviceNode, 0, len(nodes))
+	seen := make(map[string]bool, len(nodes))
+
+	for _, d := range nodes {
+		if !cdi.HasWildcards(d.Path) && !cdi.HasWildcards(d.HostPath) {
+			// NOTE: we don't dedup explicit (non-wildcard) device nodes (to not change the existing behavior).
+			// Should we drop that for wildcard expansion, too(?)
+			seen[d.Path] = true
+			expanded = append(expanded, d)
+			continue
+		}
+
+		matches, err := (&DeviceNode{d}).expand()
+		if err != nil {
+			return nil, err
+		}
+		for _, m := range matches {
+			// Don't inject a device node twice
+			if !seen[m.Path] {
+				seen[m.Path] = true
+				expanded = append(expanded, m)
+			}
+		}
+	}
+
+	return expanded, nil
+}
+
+// expand returns one new device node per host device node matching the path pattern of the device node.
+func (d *DeviceNode) expand() ([]*cdi.DeviceNode, error) {
+	pattern := d.HostPath
+	if pattern == "" {
+		pattern = d.Path
+	}
+
+	// Glob returns matches in sorted order, making this deterministic
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		// NOTE: the pattern is checked by Validate() so we should never end up here
+		return nil, fmt.Errorf("invalid device node pattern %q: %w", pattern, err)
+	}
+
+	expanded := make([]*cdi.DeviceNode, 0, len(matches))
+	for _, hostPath := range matches {
+		// Ignores matches which are not device nodes, also filtering out symlinks (like /dev/dri/by-path/*)
+		if _, err := deviceInfoFromPath(hostPath); err != nil {
+			continue
+		}
+
+		node := *d.DeviceNode
+		if node.HostPath == "" {
+			node.Path = hostPath
+		} else {
+			// NOTE: Validate() ensures that the patterns of path and hostPath are identical so we can safely do this
+			node.Path = filepath.Join(filepath.Dir(d.Path), filepath.Base(hostPath))
+			node.HostPath = hostPath
+		}
+		expanded = append(expanded, &node)
+	}
+
+	return expanded, nil
 }
 
 // fillMissingInfo fills in missing mandatory attributes from the host device.

--- a/pkg/cdi/container-edits_unix_test.go
+++ b/pkg/cdi/container-edits_unix_test.go
@@ -1,0 +1,378 @@
+//go:build !windows
+
+/*
+   Copyright © The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cdi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+	cdi "tags.cncf.io/container-device-interface/specs-go"
+)
+
+// mockDevDir creates a directory with FIFOs acting as device nodes.
+func mockDevDir(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	for _, name := range []string{"dev0", "dev1", "dev2"} {
+		require.NoError(t, unix.Mkfifo(filepath.Join(dir, name), 0o600))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dev-regular"), nil, 0o600))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "dev-subdir"), 0o700))
+	require.NoError(t, os.Symlink(filepath.Join(dir, "dev0"), filepath.Join(dir, "dev-link")))
+
+	return dir
+}
+
+func TestValidateWildcardContainerEdits(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		edits   *cdi.ContainerEdits
+		invalid bool
+	}{
+		{
+			name: "valid wildcard device",
+			edits: &cdi.ContainerEdits{
+				DeviceNodes: []*cdi.DeviceNode{
+					{
+						Path: "/dev/dri/card*",
+					},
+					{
+						Path:        "/dev/mei[0-9]",
+						Permissions: "rw",
+					},
+				},
+			},
+		},
+		{
+			name: "invalid wildcard device, in a non-final path element",
+			edits: &cdi.ContainerEdits{
+				DeviceNodes: []*cdi.DeviceNode{
+					{
+						Path: "/dev/bus/usb/*/*",
+					},
+				},
+			},
+			invalid: true,
+		},
+		{
+			name: "invalid wildcard device, in a non-final path element only",
+			edits: &cdi.ContainerEdits{
+				DeviceNodes: []*cdi.DeviceNode{
+					{
+						Path: "/dev/dri/*/card0",
+					},
+				},
+			},
+			invalid: true,
+		},
+		{
+			name: "valid wildcard device, with host path",
+			edits: &cdi.ContainerEdits{
+				DeviceNodes: []*cdi.DeviceNode{
+					{
+						Path:     "/dev/card*",
+						HostPath: "/vendorroot/dev/card*",
+					},
+				},
+			},
+		},
+		{
+			name: "invalid wildcard device, malformed pattern",
+			edits: &cdi.ContainerEdits{
+				DeviceNodes: []*cdi.DeviceNode{
+					{
+						Path: "/dev/card[0-9",
+					},
+				},
+			},
+			invalid: true,
+		},
+		{
+			name: "invalid wildcard device, relative path",
+			edits: &cdi.ContainerEdits{
+				DeviceNodes: []*cdi.DeviceNode{
+					{
+						Path: "dev/card*",
+					},
+				},
+			},
+			invalid: true,
+		},
+		{
+			name: "invalid wildcard device, uncleaned path",
+			edits: &cdi.ContainerEdits{
+				DeviceNodes: []*cdi.DeviceNode{
+					{
+						Path: "/dev/../etc/host*",
+					},
+				},
+			},
+			invalid: true,
+		},
+		{
+			name: "invalid wildcard device, uncleaned host path",
+			edits: &cdi.ContainerEdits{
+				DeviceNodes: []*cdi.DeviceNode{
+					{
+						Path:     "/dev/host*",
+						HostPath: "/vendorroot/../etc/host*",
+					},
+				},
+			},
+			invalid: true,
+		},
+		{
+			name: "invalid wildcard device, type set",
+			edits: &cdi.ContainerEdits{
+				DeviceNodes: []*cdi.DeviceNode{
+					{
+						Path: "/dev/card*",
+						Type: "c",
+					},
+				},
+			},
+			invalid: true,
+		},
+		{
+			name: "invalid wildcard device, device numbers set",
+			edits: &cdi.ContainerEdits{
+				DeviceNodes: []*cdi.DeviceNode{
+					{
+						Path:  "/dev/card*",
+						Major: 226,
+						Minor: 0,
+					},
+				},
+			},
+			invalid: true,
+		},
+		{
+			name: "invalid wildcard device, wildcards only in host path",
+			edits: &cdi.ContainerEdits{
+				DeviceNodes: []*cdi.DeviceNode{
+					{
+						Path:     "/dev/card0",
+						HostPath: "/vendorroot/dev/card*",
+					},
+				},
+			},
+			invalid: true,
+		},
+		{
+			name: "invalid wildcard device, mismatching patterns",
+			edits: &cdi.ContainerEdits{
+				DeviceNodes: []*cdi.DeviceNode{
+					{
+						Path:     "/dev/gpu*",
+						HostPath: "/vendorroot/dev/card*",
+					},
+				},
+			},
+			invalid: true,
+		},
+		{
+			name: "invalid wildcard device, wildcard directory only in host path",
+			edits: &cdi.ContainerEdits{
+				DeviceNodes: []*cdi.DeviceNode{
+					{
+						Path:     "/dev/card0",
+						HostPath: "/vendorroot/*/card0",
+					},
+				},
+			},
+			invalid: true,
+		},
+		{
+			name: "invalid wildcard device, wildcard directory only in path",
+			edits: &cdi.ContainerEdits{
+				DeviceNodes: []*cdi.DeviceNode{
+					{
+						Path:     "/dev/*/card0",
+						HostPath: "/vendorroot/dev/card0",
+					},
+				},
+			},
+			invalid: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			edits := ContainerEdits{tc.edits}
+			err := edits.Validate()
+			if tc.invalid {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestExpandWildcards(t *testing.T) {
+	dir := mockDevDir(t)
+	mode := os.FileMode(0o600)
+
+	type result struct {
+		path     string
+		hostPath string
+	}
+	type testCase struct {
+		name  string
+		nodes []*cdi.DeviceNode
+		want  []result
+	}
+	for _, tc := range []*testCase{
+		{
+			name: "no wildcards, returned as is",
+			nodes: []*cdi.DeviceNode{
+				{Path: "/dev/null"},
+				{Path: "/dev/card0", HostPath: "/vendorroot/dev/card0"},
+			},
+			want: []result{
+				{"/dev/null", ""},
+				{"/dev/card0", "/vendorroot/dev/card0"},
+			},
+		},
+		{
+			name: "wildcard expanded to matching device nodes",
+			nodes: []*cdi.DeviceNode{
+				{Path: dir + "/dev*"},
+			},
+			want: []result{
+				{dir + "/dev0", ""},
+				{dir + "/dev1", ""},
+				{dir + "/dev2", ""},
+			},
+		},
+		{
+			name: "wildcard with a separate host path",
+			nodes: []*cdi.DeviceNode{
+				{Path: "/dev/vendor/dev*", HostPath: dir + "/dev*"},
+			},
+			want: []result{
+				{"/dev/vendor/dev0", dir + "/dev0"},
+				{"/dev/vendor/dev1", dir + "/dev1"},
+				{"/dev/vendor/dev2", dir + "/dev2"},
+			},
+		},
+		{
+			name: "wildcards matching nothing are dropped",
+			nodes: []*cdi.DeviceNode{
+				{Path: dir + "/nosuchdev*"},
+				{Path: dir + "/nosuchdir/dev*"},
+			},
+			want: nil,
+		},
+		{
+			name: "overlapping wildcards are deduplicated",
+			nodes: []*cdi.DeviceNode{
+				{Path: dir + "/dev[01]"},
+				{Path: dir + "/dev*"},
+			},
+			want: []result{
+				{dir + "/dev0", ""},
+				{dir + "/dev1", ""},
+				{dir + "/dev2", ""},
+			},
+		},
+		{
+			name: "wildcard does not duplicate an explicit device node",
+			nodes: []*cdi.DeviceNode{
+				{Path: dir + "/dev0"},
+				{Path: dir + "/dev*"},
+			},
+			want: []result{
+				{dir + "/dev0", ""},
+				{dir + "/dev1", ""},
+				{dir + "/dev2", ""},
+			},
+		},
+		{
+			name: "explicit device nodes are not deduplicated",
+			nodes: []*cdi.DeviceNode{
+				{Path: dir + "/dev*"},
+				{Path: dir + "/dev0"},
+			},
+			want: []result{
+				{dir + "/dev0", ""},
+				{dir + "/dev1", ""},
+				{dir + "/dev2", ""},
+				{dir + "/dev0", ""},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded, err := expandWildcards(tc.nodes)
+			require.NoError(t, err)
+
+			got := []result(nil)
+			for _, d := range expanded {
+				got = append(got, result{d.Path, d.HostPath})
+			}
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("malformed pattern is an error", func(t *testing.T) {
+		// Validate() normally catches this before we ever get here
+		_, err := expandWildcards([]*cdi.DeviceNode{{Path: "/dev/card[0-9"}})
+		require.Error(t, err)
+	})
+
+	t.Run("properties are inherited from host", func(t *testing.T) {
+		uid, gid := uint32(1000), uint32(2000)
+		pattern := &cdi.DeviceNode{
+			Path:        dir + "/dev*",
+			Permissions: "rw",
+			FileMode:    &mode,
+			UID:         &uid,
+			GID:         &gid,
+		}
+
+		expanded, err := expandWildcards([]*cdi.DeviceNode{pattern})
+		require.NoError(t, err)
+		require.Len(t, expanded, 3)
+		for _, d := range expanded {
+			require.Equal(t, "rw", d.Permissions)
+			require.Equal(t, &mode, d.FileMode)
+			require.Equal(t, &uid, d.UID)
+			require.Equal(t, &gid, d.GID)
+		}
+	})
+
+	t.Run("fill missing info does not modify the pattern", func(t *testing.T) {
+		pattern := &cdi.DeviceNode{Path: dir + "/dev*"}
+		edits := &ContainerEdits{&cdi.ContainerEdits{DeviceNodes: []*cdi.DeviceNode{pattern}}}
+
+		for range 2 {
+			spec := &oci.Spec{}
+			require.NoError(t, edits.Apply(spec))
+			require.Len(t, spec.Linux.Devices, 3)
+
+			require.Equal(t, dir+"/dev*", pattern.Path)
+			require.Equal(t, "", pattern.HostPath)
+			require.Equal(t, "", pattern.Type)
+			require.Nil(t, pattern.FileMode)
+		}
+	})
+}

--- a/pkg/cdi/container-edits_windows.go
+++ b/pkg/cdi/container-edits_windows.go
@@ -18,7 +18,21 @@
 
 package cdi
 
-import "fmt"
+import (
+	"fmt"
+
+	cdi "tags.cncf.io/container-device-interface/specs-go"
+)
+
+// validateWildcards is a no-op on Windows as device nodes are unsupported.
+func (d *DeviceNode) validateWildcards() error {
+	return nil
+}
+
+// expandWildcards is a no-op on Windows, as device nodes are unsupported.
+func expandWildcards(nodes []*cdi.DeviceNode) ([]*cdi.DeviceNode, error) {
+	return nodes, nil
+}
 
 // fillMissingInfo fills in missing mandatory attributes from the host device.
 func (d *DeviceNode) fillMissingInfo() error {

--- a/schema/testdata/good/wildcards.json
+++ b/schema/testdata/good/wildcards.json
@@ -1,0 +1,17 @@
+{
+  "cdiVersion": "1.2.0",
+  "kind": "vendor.com/device",
+  "devices": [
+    {
+      "name": "all",
+      "containerEdits": {
+        "deviceNodes": [
+          {"path": "/dev/dri/card*"},
+          {"path": "/dev/dri/renderD*"},
+          {"path": "/dev/mei[0-9]", "permissions": "rw"},
+          {"hostPath": "/vendorroot/dev/card*", "path": "/dev/vendor/card*"}
+        ]
+      }
+    }
+  ]
+}

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -22,7 +22,7 @@ import (
 )
 
 // CurrentVersion is the current version of the Spec.
-const CurrentVersion = "1.1.0"
+const CurrentVersion = "1.2.0"
 
 const (
 	// These represent the released versions of the CDI specification
@@ -36,6 +36,7 @@ const (
 	v080 version = "0.8.0"
 	v100 version = "1.0.0"
 	v110 version = "1.1.0"
+	v120 version = "1.2.0"
 
 	// vEarliest is the earliest supported version of the CDI specification
 	vEarliest version = v030
@@ -49,6 +50,7 @@ var validSpecVersions = []struct {
 	version    version
 	isRequired requiredFunc
 }{
+	{v120, requiresV120},
 	{v110, requiresV110},
 	{v100, requiresV100},
 	{v080, requiresV080},
@@ -126,6 +128,27 @@ func versionIndex(v version) int {
 		}
 	}
 	return -1
+}
+
+// requiresV120 returns true if the spec uses v1.2.0 features.
+func requiresV120(spec *Spec) bool {
+	var edits []*ContainerEdits
+
+	for _, d := range spec.Devices {
+		edits = append(edits, &d.ContainerEdits)
+	}
+
+	edits = append(edits, &spec.ContainerEdits)
+	for _, e := range edits {
+		for _, dn := range e.DeviceNodes {
+			// Wildcards in the paths of device nodes were added in v1.2.0.
+			if HasWildcards(dn.Path) || HasWildcards(dn.HostPath) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // requiresV110 returns true if the spec uses v1.1.0 features.

--- a/specs-go/version_test.go
+++ b/specs-go/version_test.go
@@ -119,6 +119,45 @@ func TestMinimumRequiredVersion(t *testing.T) {
 			want: "1.1.0",
 		},
 		{
+			doc: "v1.2.0 wildcard device node path",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					DeviceNodes: []*specs.DeviceNode{{Path: "/dev/dri/card*"}},
+				},
+			},
+			want: "1.2.0",
+		},
+		{
+			doc: "v1.2.0 wildcard device node host path",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					DeviceNodes: []*specs.DeviceNode{{
+						Path:     "/dev/card[0-9]",
+						HostPath: "/vendorroot/dev/card[0-9]",
+					}},
+				},
+			},
+			want: "1.2.0",
+		},
+		{
+			doc: "v1.2.0 escaped wildcard is still a pattern",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					DeviceNodes: []*specs.DeviceNode{{Path: `/dev/literal\*`}},
+				},
+			},
+			want: "1.2.0",
+		},
+		{
+			doc: "no wildcards in device node paths",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					DeviceNodes: []*specs.DeviceNode{{Path: "/dev/card0"}},
+				},
+			},
+			want: "0.3.0",
+		},
+		{
 			doc: "device-scoped feature",
 			spec: &specs.Spec{
 				Devices: []specs.Device{{
@@ -128,6 +167,17 @@ func TestMinimumRequiredVersion(t *testing.T) {
 				}},
 			},
 			want: "0.7.0",
+		},
+		{
+			doc: "device-scoped wildcard device node path",
+			spec: &specs.Spec{
+				Devices: []specs.Device{{
+					ContainerEdits: specs.ContainerEdits{
+						DeviceNodes: []*specs.DeviceNode{{Path: "/dev/mei*"}},
+					},
+				}},
+			},
+			want: "1.2.0",
 		},
 		{
 			doc: "newest feature wins",
@@ -164,12 +214,12 @@ func TestValidateVersion(t *testing.T) {
 	}{
 		{
 			doc:     "current version",
-			version: "1.1.0",
+			version: "1.2.0",
 			spec:    &specs.Spec{},
 		},
 		{
 			doc:     "optional v prefix",
-			version: "v1.1.0",
+			version: "v1.2.0",
 			spec:    &specs.Spec{},
 		},
 		{
@@ -191,9 +241,19 @@ func TestValidateVersion(t *testing.T) {
 		},
 		{
 			doc:     "unknown version",
-			version: "1.2.0",
+			version: "1.3.0",
 			spec:    &specs.Spec{},
-			wantErr: `invalid version "1.2.0"`,
+			wantErr: `invalid version "1.3.0"`,
+		},
+		{
+			doc:     "version too old for wildcard device node",
+			version: "1.1.0",
+			spec: &specs.Spec{
+				ContainerEdits: specs.ContainerEdits{
+					DeviceNodes: []*specs.DeviceNode{{Path: "/dev/dri/card*"}},
+				},
+			},
+			wantErr: "the spec version must be at least v1.2.0",
 		},
 		{
 			doc:     "malformed version",

--- a/specs-go/wildcard.go
+++ b/specs-go/wildcard.go
@@ -1,0 +1,31 @@
+/*
+   Copyright © The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package specs
+
+import "strings"
+
+const wildcardMetaChars = `*?[`
+
+// HasWildcards reports whether the given device node path is a wildcard
+// pattern.
+//
+// NOTE: a path containing a meta character is always treated as a pattern,
+// even if the meta character is escaped with a backslash. Escaping only affects
+// what the pattern matches, not whether the path is a pattern.
+func HasWildcards(path string) bool {
+	return strings.ContainsAny(path, wildcardMetaChars)
+}

--- a/specs-go/wildcard_test.go
+++ b/specs-go/wildcard_test.go
@@ -1,0 +1,52 @@
+/*
+   Copyright © The CDI Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package specs_test
+
+import (
+	"testing"
+
+	"tags.cncf.io/container-device-interface/specs-go"
+)
+
+func TestHasWildcards(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: "", want: false},
+		{path: "/dev/null", want: false},
+		{path: "/dev/dri/card0", want: false},
+		{path: "/dev/dri/card*", want: true},
+		{path: "/dev/dri/renderD*", want: true},
+		{path: "/dev/mei*", want: true},
+		{path: "/dev/card?", want: true},
+		{path: "/dev/card[0-9]", want: true},
+		{path: "/dev/*/card0", want: true},
+		// An escaped asterisk still makes the path a pattern.
+		{path: `/dev/literal\*`, want: true},
+		// A closing bracket alone is not a meta character.
+		{path: "/dev/card]", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			if got := specs.HasWildcards(tc.path); got != tc.want {
+				t.Errorf("HasWildcards(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allows the `path` and `hostPath` of a `deviceNodes` entry to be a wildcard pattern, so a device can cover all instances of a class of device nodes without the vendor having to enumerate them. An example:

```yaml
cdiVersion: "1.2.0"
kind: "vendor.com/device"
devices:
  - name: "all"
    containerEdits:
      deviceNodes:
        - path: "/dev/dri/card*"
        - path: "/dev/mei[1-9]"
          permissions: "rw"
```

Patterns use [`path.Match`](https://pkg.go.dev/path#Match) syntax. Each match becomes a device node
of its own. Non-device matches (regular files, directories, symlinks) are ignored, and a pattern matching nothing expands to an empty list. The `type`, `major` and `minor` fields are inherited from the host device node and cannot be specified.

Also bumps the spec version to v1.2.0.